### PR TITLE
Integrity check issues when creating delete jobs with IObjectRemovedEvent

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.0 (unreleased)
 ----------------
 
+- Make status messages transaction aware, so that it works with integrity check rollbacks.
+  [jone]
+
 - Implement an ``override-realm`` ZCML directive for overriding database settings with ZCML.
   [jone]
 

--- a/ftw/publisher/sender/browser/views.py
+++ b/ftw/publisher/sender/browser/views.py
@@ -11,6 +11,7 @@ from ftw.publisher.sender import message_factory as _
 from ftw.publisher.sender.events import AfterPushEvent, QueueExecutedEvent
 from ftw.publisher.sender.events import BeforeQueueExecutionEvent
 from ftw.publisher.sender.interfaces import IPathBlacklist, IConfig, IQueue
+from ftw.publisher.sender.utils import add_transaction_aware_status_message
 from ftw.publisher.sender.utils import sendJsonToRealm
 from threading import RLock
 from urllib2 import URLError
@@ -71,6 +72,7 @@ class PublishObject(BrowserView):
                 self.context.Title(),
                 '/'.join(self.context.getPhysicalPath()),
                 ))
+
         # status message
         if msg is None:
             msg = _(u'This object has been added to the queue.')
@@ -175,13 +177,12 @@ class DeleteObject(BrowserView):
                 self.context.Title(),
                 '/'.join(self.context.getPhysicalPath()),
                 ))
+
         # status message
         if msg is None:
             msg = _(u'This object will be deleted at the remote sites.')
-        IStatusMessage(self.request).addStatusMessage(
-            msg,
-            type='info'
-            )
+        add_transaction_aware_status_message(self.request, msg, type='info')
+
         if not no_response:
             return self.request.RESPONSE.redirect('./view')
 

--- a/ftw/publisher/sender/tests/test_views.py
+++ b/ftw/publisher/sender/tests/test_views.py
@@ -1,12 +1,13 @@
-import unittest
-
-from Products.PloneTestCase.ptc import PloneTestCase
-from ftw.publisher.sender.tests.layer import Layer
-
+from Products.PloneTestCase import ptc
+from Products.statusmessages.interfaces import IStatusMessage
 from ftw.publisher.sender.browser.views import PublishObject, DeleteObject
 from ftw.publisher.sender.persistence import Queue
+from ftw.publisher.sender.tests.layer import Layer
+import transaction
+import unittest
 
-class TestPublishObject(PloneTestCase):
+
+class TestPublishObject(ptc.PloneTestCase):
     layer = Layer
 
     def afterSetUp(self):
@@ -25,13 +26,18 @@ class TestPublishObject(PloneTestCase):
         self.assertEquals(isinstance(PublishObject(self.portal,self.portal.REQUEST), PublishObject), True)
 
 
-class TestDeleteObject(PloneTestCase):
+class TestDeleteObject(ptc.FunctionalTestCase):
+
     layer = Layer
 
     def afterSetUp(self):
         # add some default plone types
         testdoc2id = self.folder.invokeFactory('Document', 'test-doc-2')
         self.testdoc2 = getattr(self.folder,testdoc2id,None)
+
+    def get_status_messages(self):
+        return map(lambda msg: str(msg.message),
+                   IStatusMessage(self.testdoc2.REQUEST).show())
 
     def test_delete_object(self):
         queue = Queue(self.testdoc2)
@@ -40,8 +46,32 @@ class TestDeleteObject(PloneTestCase):
         self.assertEquals(queue.countJobs(),1)
         self.assertEquals(queue.getJobs()[0].action,'delete')
 
+        transaction.commit()
+        self.assertEquals(
+            self.get_status_messages(),
+            ['This object will be deleted at the remote sites.'])
+
     def test_delete_plonesiteroot(self):
-        self.assertRaises(Exception, DeleteObject(self.portal,self.portal.REQUEST))
+        self.assertRaises(Exception, DeleteObject(
+                self.portal,self.portal.REQUEST))
+
+    def test_delete_with_rollback(self):
+        # This test simulates Products.CMFPlone.utils.isLinked which
+        # deletes and rolls back for integrity checking.
+        # When it is rolled back it should create a status message.
+        queue = Queue(self.testdoc2)
+        self.assertEquals(queue.countJobs(), 0)
+
+        savepoint = transaction.savepoint()
+        DeleteObject(self.testdoc2, self.testdoc2.REQUEST)()
+        self.assertEquals(queue.countJobs(), 1)
+
+        savepoint.rollback()
+        self.assertEquals(queue.countJobs(), 0)
+
+        transaction.commit()
+        self.assertEquals(self.get_status_messages(), [])
+
 
 
 


### PR DESCRIPTION
In integration packages we often subscribe a `IObjectRemovedEvent` event handler, calling the `publisher.delete` view when necessary. This caused issues with the integrity check.

**Situation**

When visiting delete_confirmation (not yet confirmed) the `Products.CMFPlone.utils.isLinked` function makes an integrity check by deleting the content in a savepoint, which is rolled back later.

This caused the "object was deleted" status message to appear when just visiting the confirmation page and also when canceling, but it should only appear when actually clicking "Delete" (although the Delete-Job is rolled back correctly).

For addressing this issue I've made a `add_transaction_aware_status_message` which only adds the status message after committing to the ZODB and  only if the committed transaction did not have savepoints at the time `publisher.delete` was executed which were rolled back afterwards (which is usually only the case when within link integrity check).

This Fixes 4teamwork/ftw.publisher.sender#6 in a less integrity-check-centric way so that the delete view is still generic.

/cc @maethu 
