### PR TITLE
add ftw.simplelayout support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ftw.simplelayout support.
+  [jone]
 
 
 2.2.2 (2015-03-19)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
+- Drop Plone 4.2 support.
+  [jone]
+
 - Add ftw.simplelayout support.
   [jone]
 

--- a/ftw/publisher/sender/browser/configure.zcml
+++ b/ftw/publisher/sender/browser/configure.zcml
@@ -41,6 +41,32 @@
           />
   </configure>
 
+  <configure zcml:condition="installed ftw.simplelayout">
+      <browser:page
+          name="publisher.publish"
+          for="ftw.simplelayout.interfaces.ISimplelayout"
+          class=".sl.PublishSimplelayoutContainer"
+          permission="zope2.View"
+          />
+
+      <browser:page
+          name="publisher.publish"
+          for="ftw.simplelayout.interfaces.ISimplelayoutBlock"
+          class=".sl.PublishFolderishSimplelayoutBlocks"
+          permission="zope2.View"
+          />
+
+      <configure zcml:condition="not-installed simplelayout.base">
+          <browser:page
+              zcml:condition="installed ftw.subsite"
+              name="publisher.publish"
+              for="ftw.subsite.interfaces.ISubsite"
+              class=".sl.PublishSimplelayoutContainer"
+              permission="zope2.View"
+              />
+      </configure>
+  </configure>
+
   <browser:page
       name="publisher.move"
       for="*"

--- a/ftw/publisher/sender/browser/sl.py
+++ b/ftw/publisher/sender/browser/sl.py
@@ -1,7 +1,33 @@
 from ftw.publisher.sender.browser.views import PublishObject
 from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
-from simplelayout.base.interfaces import ISimpleLayoutBlock
 from zope.component import getMultiAdapter
+import pkg_resources
+
+SL_BLOCK_INTERFACES = []
+
+try:
+    pkg_resources.get_distribution('simplelayout.base')
+except pkg_resources.DistributionNotFound:
+    pass
+else:
+    from simplelayout.base.interfaces import ISimpleLayoutBlock
+    SL_BLOCK_INTERFACES.append(ISimpleLayoutBlock)
+
+
+try:
+    pkg_resources.get_distribution('ftw.simplelayout')
+except pkg_resources.DistributionNotFound:
+    pass
+else:
+    from ftw.simplelayout.interfaces import ISimplelayoutBlock
+    SL_BLOCK_INTERFACES.append(ISimplelayoutBlock)
+
+
+def is_simplelayout_block(context):
+    for iface in SL_BLOCK_INTERFACES:
+        if iface.providedBy(context):
+            return True
+    return False
 
 
 class PublishSimplelayoutContainer(PublishObject):
@@ -11,7 +37,7 @@ class PublishSimplelayoutContainer(PublishObject):
             *args, **kwargs)
 
         for obj in self.context.objectValues():
-            if not ISimpleLayoutBlock.providedBy(obj):
+            if not is_simplelayout_block(obj):
                 continue
 
             state = getMultiAdapter((obj, self.request),

--- a/ftw/publisher/sender/testing.py
+++ b/ftw/publisher/sender/testing.py
@@ -42,9 +42,11 @@ class PublisherSenderLayer(PloneSandboxLayer):
         z2.installProduct(app, 'simplelayout.base')
         z2.installProduct(app, 'simplelayout.ui.base')
         z2.installProduct(app, 'simplelayout.ui.dragndrop')
+        z2.installProduct(app, 'ftw.simplelayout')
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.contentpage:default')
+        applyProfile(portal, 'ftw.simplelayout:default')
         applyProfile(portal, 'ftw.publisher.sender:default')
         applyProfile(portal, 'ftw.publisher.sender:example-workflow')
 

--- a/ftw/publisher/sender/tests/builders.py
+++ b/ftw/publisher/sender/tests/builders.py
@@ -1,5 +1,6 @@
 from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
+import ftw.simplelayout.tests.builders
 
 
 class ContentPageBuilder(ArchetypesBuilder):

--- a/ftw/publisher/sender/tests/test_simplelayout.py
+++ b/ftw/publisher/sender/tests/test_simplelayout.py
@@ -16,6 +16,11 @@ class TestPublishingSimplelayoutTypes(TestCase):
 
     layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
 
+    portal_type = 'ContentPage'
+    page_builder = 'content page'
+    textblock_builder = 'text block'
+    listingblock_builder = 'listing block'
+
     def setUp(self):
         super(TestPublishingSimplelayoutTypes, self).setUp()
 
@@ -24,12 +29,12 @@ class TestPublishingSimplelayoutTypes(TestCase):
         login(self.portal, TEST_USER_NAME)
 
         wftool = getToolByName(self.portal, 'portal_workflow')
-        wftool.setChainForPortalTypes(['ContentPage'],
+        wftool.setChainForPortalTypes([self.portal_type],
                                       'publisher-example-workflow')
 
     def test_blocks_are_published_with_contentpage(self):
-        page = create(Builder('content page'))
-        create(Builder('text block').within(page))
+        page = create(Builder(self.page_builder))
+        create(Builder(self.textblock_builder).within(page))
 
         Plone().login().visit(page)
         Workflow().do_transition('publish')
@@ -40,8 +45,8 @@ class TestPublishingSimplelayoutTypes(TestCase):
             'Expected the page and the text block to be in the queue.')
 
     def test_sl_listing_block_publishes_its_children(self):
-        page = create(Builder('content page'))
-        listing_block = create(Builder('listing block').within(page))
+        page = create(Builder(self.page_builder))
+        listing_block = create(Builder(self.listingblock_builder).within(page))
         create(Builder('file').within(listing_block))
 
         Plone().login().visit(page)
@@ -52,3 +57,11 @@ class TestPublishingSimplelayoutTypes(TestCase):
             3, queue.countJobs(),
             'Expected the page, the listing block and the file to be'
             ' in the queue.')
+
+
+class TestPublishingNEWSimplelayoutTypes(TestPublishingSimplelayoutTypes):
+
+    portal_type = 'ftw.simplelayout.ContentPage'
+    page_builder = 'sl content page'
+    textblock_builder = 'sl textblock'
+    listingblock_builder = 'sl listingblock'

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ tests_require = [
     'ftw.lawgiver',
     'ftw.builder',
     'ftw.contentpage',
+    'ftw.simplelayout [contenttypes]',
     ]
 
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -4,4 +4,7 @@ extends = http://plonesource.org/sources.cfg
 auto-checkout =
     ftw.publisher.core
 
+# Wait for first release
+    ftw.simplelayout
+
 extensions = mr.developer

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,7 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    sources.cfg
-    versions.cfg
-
-package-name = ftw.publisher.sender


### PR DESCRIPTION
This automatically adds support for ftw.simplelayout pages when the package is installed.
When a page is published, all contained blocks without a workflow are published as well.

The back-references checks, which are done for the old archetypes simplelayout implementation, are not yet done, because this does not work well with dexterity.