### PR TITLE
ftw.simplelayout: sync page config before publishing.

### DIFF
--- a/ftw/publisher/sender/browser/configure.zcml
+++ b/ftw/publisher/sender/browser/configure.zcml
@@ -45,7 +45,7 @@
       <browser:page
           name="publisher.publish"
           for="ftw.simplelayout.interfaces.ISimplelayout"
-          class=".sl.PublishSimplelayoutContainer"
+          class=".sl.PublishFtwSimplelayoutContainer"
           permission="zope2.View"
           />
 

--- a/ftw/publisher/sender/browser/sl.py
+++ b/ftw/publisher/sender/browser/sl.py
@@ -21,6 +21,7 @@ except pkg_resources.DistributionNotFound:
 else:
     from ftw.simplelayout.interfaces import ISimplelayoutBlock
     SL_BLOCK_INTERFACES.append(ISimplelayoutBlock)
+    from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
 
 
 def is_simplelayout_block(context):
@@ -48,6 +49,14 @@ class PublishSimplelayoutContainer(PublishObject):
             obj.restrictedTraverse('@@publisher.publish')(*args, **kwargs)
 
         return result
+
+
+class PublishFtwSimplelayoutContainer(PublishSimplelayoutContainer):
+
+    def __call__(self, *args, **kwargs):
+        synchronize_page_config_with_blocks(self.context)
+        super(PublishFtwSimplelayoutContainer, self).__call__(*args, **kwargs)
+
 
 
 class PublishFolderishSimplelayoutBlocks(PublishObject):

--- a/ftw/publisher/sender/tests/test_simplelayout.py
+++ b/ftw/publisher/sender/tests/test_simplelayout.py
@@ -1,14 +1,17 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.publisher.sender.interfaces import IQueue
 from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
 from ftw.publisher.sender.tests.pages import Workflow
+from ftw.simplelayout.configuration import flattened_block_uids
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.testing import staticuid
 from ftw.testing.pages import Plone
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 
 
@@ -86,3 +89,13 @@ class TestPublishingNEWSimplelayoutTypes(TestPublishingSimplelayoutTypes):
         self.assertEquals(1, IQueue(self.portal).countJobs(),
                           'Deleteing an ftw.simplelayout page'
                           ' should still add a delete job.')
+
+    @staticuid('staticuid')
+    def test_syncs_pagestate_before_publishing(self):
+        page = create(Builder('sl content page'))
+        create(Builder('sl textblock').within(page))
+        self.assertEquals([], flattened_block_uids(IPageConfiguration(page).load()))
+
+        page.restrictedTraverse('@@publisher.publish')()
+        self.assertEquals(['staticuid00000000000000000000002'],
+                          flattened_block_uids(IPageConfiguration(page).load()))


### PR DESCRIPTION
By syncing the page config before publishing the page, we make sure the config is up to date.
Especially we want to remove UID-references to no longer existing
blocks, so that those blocks are removed at the receiver side.

Related to https://github.com/4teamwork/ftw.publisher.receiver/pull/9