### PR TITLE
do not publish delete blocks for ftw.simplelayout blocks.

### DIFF
--- a/ftw/publisher/sender/tests/test_simplelayout.py
+++ b/ftw/publisher/sender/tests/test_simplelayout.py
@@ -65,3 +65,24 @@ class TestPublishingNEWSimplelayoutTypes(TestPublishingSimplelayoutTypes):
     page_builder = 'sl content page'
     textblock_builder = 'sl textblock'
     listingblock_builder = 'sl listingblock'
+
+    def test_no_delete_jobs_for_blocks(self):
+        """When a block is deleted, we do not want to instantly delete
+        the block on the receiver side.
+        Instead the block is deleted automatically when the page is published
+        because it is no longer listed in the page state.
+        """
+
+        page = create(Builder(self.page_builder))
+        textblock = create(Builder(self.textblock_builder).within(page))
+
+        self.assertEquals(0, IQueue(self.portal).countJobs())
+        page.manage_delObjects([textblock.getId()])
+        self.assertEquals(0, IQueue(self.portal).countJobs(),
+                          'Deleting an ftw.simplelayout block'
+                          ' should not publish a delete job.')
+
+        self.portal.manage_delObjects([page.getId()])
+        self.assertEquals(1, IQueue(self.portal).countJobs(),
+                          'Deleteing an ftw.simplelayout page'
+                          ' should still add a delete job.')


### PR DESCRIPTION
ftw.simplelayout blocks are removed on the receiver side when the page
is published and the block is no longer in the page config.
Therefore the block should not be deleted with a delete job.

This makes it possible to remove blocks without having them removed too
early from the receiver side.
The idea here is that the block is part of the page's content and not
seen as separate, standalone object.