### PR TITLE
refactor ftw.simplelayout: use is_sl_contentish.

### DIFF
--- a/ftw/publisher/sender/browser/configure.zcml
+++ b/ftw/publisher/sender/browser/configure.zcml
@@ -45,26 +45,16 @@
       <browser:page
           name="publisher.publish"
           for="ftw.simplelayout.interfaces.ISimplelayout"
-          class=".sl.PublishFtwSimplelayoutContainer"
+          class=".ftw_simplelayout.PublishSLContainer"
           permission="zope2.View"
           />
 
       <browser:page
           name="publisher.publish"
           for="ftw.simplelayout.interfaces.ISimplelayoutBlock"
-          class=".sl.PublishFolderishSimplelayoutBlocks"
+          class=".ftw_simplelayout.PublishSLObject"
           permission="zope2.View"
           />
-
-      <configure zcml:condition="not-installed simplelayout.base">
-          <browser:page
-              zcml:condition="installed ftw.subsite"
-              name="publisher.publish"
-              for="ftw.subsite.interfaces.ISubsite"
-              class=".sl.PublishSimplelayoutContainer"
-              permission="zope2.View"
-              />
-      </configure>
   </configure>
 
   <browser:page

--- a/ftw/publisher/sender/browser/ftw_simplelayout.py
+++ b/ftw/publisher/sender/browser/ftw_simplelayout.py
@@ -1,0 +1,21 @@
+from ftw.publisher.core.adapters.ftw_simplelayout import is_sl_contentish
+from ftw.publisher.sender.browser.views import PublishObject
+from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
+
+
+class PublishSLObject(PublishObject):
+
+    def __call__(self, *args, **kwargs):
+        result = super(PublishSLObject, self).__call__(*args, **kwargs)
+
+        for obj in filter(is_sl_contentish, self.context.objectValues()):
+            obj.restrictedTraverse('@@publisher.publish')(*args, **kwargs)
+
+        return result
+
+
+class PublishSLContainer(PublishSLObject):
+
+    def __call__(self, *args, **kwargs):
+        synchronize_page_config_with_blocks(self.context)
+        return super(PublishSLContainer, self).__call__(*args, **kwargs)

--- a/ftw/publisher/sender/browser/sl.py
+++ b/ftw/publisher/sender/browser/sl.py
@@ -1,27 +1,10 @@
 from ftw.publisher.sender.browser.views import PublishObject
 from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
+from simplelayout.base.interfaces import ISimpleLayoutBlock
 from zope.component import getMultiAdapter
-import pkg_resources
-
-SL_BLOCK_INTERFACES = []
-
-try:
-    pkg_resources.get_distribution('simplelayout.base')
-except pkg_resources.DistributionNotFound:
-    pass
-else:
-    from simplelayout.base.interfaces import ISimpleLayoutBlock
-    SL_BLOCK_INTERFACES.append(ISimpleLayoutBlock)
 
 
-try:
-    pkg_resources.get_distribution('ftw.simplelayout')
-except pkg_resources.DistributionNotFound:
-    pass
-else:
-    from ftw.simplelayout.interfaces import ISimplelayoutBlock
-    SL_BLOCK_INTERFACES.append(ISimplelayoutBlock)
-    from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
+SL_BLOCK_INTERFACES = [ISimpleLayoutBlock]
 
 
 def is_simplelayout_block(context):
@@ -49,14 +32,6 @@ class PublishSimplelayoutContainer(PublishObject):
             obj.restrictedTraverse('@@publisher.publish')(*args, **kwargs)
 
         return result
-
-
-class PublishFtwSimplelayoutContainer(PublishSimplelayoutContainer):
-
-    def __call__(self, *args, **kwargs):
-        synchronize_page_config_with_blocks(self.context)
-        super(PublishFtwSimplelayoutContainer, self).__call__(*args, **kwargs)
-
 
 
 class PublishFolderishSimplelayoutBlocks(PublishObject):

--- a/ftw/publisher/sender/workflows/subscribers.py
+++ b/ftw/publisher/sender/workflows/subscribers.py
@@ -17,7 +17,7 @@ except pkg_resources.DistributionNotFound:
     FTW_SIMPLELAYOUT_AVAILABLE = False
 else:
     FTW_SIMPLELAYOUT_AVAILABLE = True
-    from ftw.simplelayout.interfaces import ISimplelayoutBlock
+    from ftw.publisher.core.adapters.ftw_simplelayout import is_sl_contentish
 
 
 _marker = '_publisher_event_already_handled'
@@ -69,15 +69,14 @@ def handle_remove_event(context, event):
     Before a object is remvoed the event handler crates a remove job.
     """
 
-    if FTW_SIMPLELAYOUT_AVAILABLE and ISimplelayoutBlock.providedBy(context):
-        # ftw.simplalyout blocks should not be deleted with a delete job
-        # but are deleted by the receiver when the page is published
-        # and the block is no longer in the pagestate.
-        return
-
     # the event is notified for every subobject, but we only want to check
     # the top object which the users tries to delete
     if context is not event.object:
+        return
+
+    if FTW_SIMPLELAYOUT_AVAILABLE and is_sl_contentish(context):
+        # Do not delete sl contentish objects, they are deleted when the
+        # associated sl container is published.
         return
 
     # Find the workflow object by walking up. We may be deleting a file


### PR DESCRIPTION
Change the ftw.simplelayout integration to use the helper function `is_sl_contentish` from the ftw.publisher.core adapter.
This function should be used as basis for ftw.simplelayout related decisions regarding recursive publishing or delete jobs.