### PR TITLE
Support parents without workflows in contenxt state.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Workflow context state: skip parents without workflow when looking for
+  parent state.
+  This adds support for nested containers without workflows. [jone]
 
 
 2.3.1 (2015-12-23)

--- a/ftw/publisher/sender/tests/test_workflow_context_state.py
+++ b/ftw/publisher/sender/tests/test_workflow_context_state.py
@@ -115,6 +115,22 @@ class TestPublisherContextState(TestCase):
         self.assertFalse(get_state(page).is_parent_published(),
                         'Expected parent folder not to be published')
 
+    def test_is_parent_published__positive__when_parent_has_no_workflow(self):
+        folder = create(Builder('folder').in_state(EXAMPLE_WF_PUBLISHED))
+        page = create(Builder('content page').within(folder))  # no wf
+        subpage = create(Builder('content page').within(page))  # no wf
+
+        self.assertTrue(get_state(subpage).is_parent_published(),
+                        'Expected parent folder not to be published')
+
+    def test_is_parent_published__negeative__when_parent_has_no_workflow(self):
+        folder = create(Builder('folder').in_state(EXAMPLE_WF_INTERNAL))
+        page = create(Builder('content page').within(folder))  # no wf
+        subpage = create(Builder('content page').within(page))  # no wf
+
+        self.assertFalse(get_state(subpage).is_parent_published(),
+                         'Expected parent folder not to be published')
+
     def test_getting_unpublished_references(self):
         foo = create(Builder('page').titled('Foo'))
         bar = create(Builder('page').titled('Bar'))


### PR DESCRIPTION
Extend workflow context state so that we  skip parents without workflow when looking for  parent state.

This adds support for nested containers without workflows which contain other objects which have a workflow.