### PR TITLE
Add context manager for disabling job creation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,6 +286,17 @@ If you write custom constraints you should also take at the
 `example constraints tests <https://github.com/4teamwork/ftw.publisher.sender/blob/master/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py>`_.
 
 
+Disable creating publisher jobs
+-------------------------------
+
+.. code:: python
+
+    from ftw.publisher.sender.nojobs import publisher_jobs_disabled
+
+    with publisher_jobs_disabled():
+        pass  # no publisher jobs created here.
+
+
 Links
 =====
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add context manager for disabling job creation. [jone]
 
 
 2.4.0 (2016-05-20)

--- a/ftw/publisher/sender/nojobs.py
+++ b/ftw/publisher/sender/nojobs.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+from zope.interface import Interface
+from zope.interface import noLongerProvides
+
+
+class IPublisherJobsDisabled(Interface):
+    """Request marker interface for when no
+    publisher jobs should be added.
+    """
+
+
+@contextmanager
+def publisher_jobs_disabled():
+    """Do not add publisher jobs within this context manager.
+    """
+    request = getRequest()
+    if not request:
+        raise ValueError('Cannot disable publisher jobs:'
+                         ' there is no global request.')
+
+    alsoProvides(request, IPublisherJobsDisabled)
+    try:
+        yield
+    finally:
+        noLongerProvides(request, IPublisherJobsDisabled)
+
+
+def publisher_jobs_are_disabled():
+    request = getRequest()
+    if not request:
+        return False
+    return IPublisherJobsDisabled.providedBy(request)

--- a/ftw/publisher/sender/persistence.py
+++ b/ftw/publisher/sender/persistence.py
@@ -1,19 +1,20 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
 from Acquisition import aq_inner
 from BTrees.IOBTree import IOBTree
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from Products.Transience.Transience import Increaser
 from ftw.publisher.core import states
 from ftw.publisher.sender import extractor
 from ftw.publisher.sender.interfaces import IConfig
 from ftw.publisher.sender.interfaces import IOverriddenRealmRegistry
 from ftw.publisher.sender.interfaces import IQueue
 from ftw.publisher.sender.interfaces import IRealm
+from ftw.publisher.sender.nojobs import publisher_jobs_are_disabled
 from persistent import Persistent
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone.memoize import instance
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.Transience.Transience import Increaser
 from zope import interface, component
 from zope.annotation.interfaces import IAnnotations
 from zope.annotation.interfaces import IAttributeAnnotatable
@@ -281,6 +282,9 @@ class Queue(object):
         @type:          Job
         @return:        None
         """
+        if publisher_jobs_are_disabled():
+            return None
+
         if not isinstance(job, Job):
             raise TypeError('Excpected Job object')
         list = self.getJobs()
@@ -296,6 +300,9 @@ class Queue(object):
         @return:    Job object
         @rtype:     Job
         """
+        if publisher_jobs_are_disabled():
+            return None
+
         job = Job(*args, **kwargs)
         self.appendJob(job)
         return job

--- a/ftw/publisher/sender/tests/test_nojobs.py
+++ b/ftw/publisher/sender/tests/test_nojobs.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.publisher.sender.interfaces import IQueue
+from ftw.publisher.sender.nojobs import publisher_jobs_disabled
+from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from unittest2 import TestCase
+
+
+class TestNoJobs(TestCase):
+    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_publish(self):
+        page = create(Builder('page'))
+        queue = IQueue(self.portal)
+        self.assertEquals(0, queue.countJobs())
+
+        with publisher_jobs_disabled():
+            page.restrictedTraverse('@@publisher.publish')()
+        self.assertEquals(0, queue.countJobs())
+
+        page.restrictedTraverse('@@publisher.publish')()
+        self.assertEquals(1, queue.countJobs())
+
+    def test_delete(self):
+        page = create(Builder('page'))
+        queue = IQueue(self.portal)
+        self.assertEquals(0, queue.countJobs())
+
+        with publisher_jobs_disabled():
+            page.restrictedTraverse('@@publisher.delete')()
+        self.assertEquals(0, queue.countJobs())
+
+        page.restrictedTraverse('@@publisher.delete')()
+        self.assertEquals(1, queue.countJobs())


### PR DESCRIPTION
The context manager prevents jobs being created or added to the queue.
This is helpful when doing certain maintenance tasks which should not
create jobs / not be synced.