### PR TITLE
Reduce conflict errors by using zc.queue

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
+- Migrate queue storage to zc.queue. [jone]
+
 - Speedup enqueuing by logging less. [jone]
 
 - Support dexterity relations. [mbaechtold]

--- a/ftw/publisher/sender/browser/configlet.py
+++ b/ftw/publisher/sender/browser/configlet.py
@@ -505,7 +505,7 @@ class ExecutedJobDetails(PublisherConfigletView):
 class CleanJobs(PublisherConfigletView):
 
     def __call__(self, *args, **kwargs):
-        self.queue._setJobs(PersistentList())
+        self.queue.clearJobs()
         self.statusMessage('Removed all jobs from queue')
         return self.request.RESPONSE.redirect('./@@publisher-config')
 

--- a/ftw/publisher/sender/persistence.py
+++ b/ftw/publisher/sender/persistence.py
@@ -20,6 +20,7 @@ from zope.annotation.interfaces import IAnnotations
 from zope.annotation.interfaces import IAttributeAnnotatable
 import os
 import time
+import zc.queue
 
 
 _marker = object()
@@ -253,23 +254,28 @@ class Queue(object):
         self.context = aq_inner(context.portal_url.getPortalObject())
         self.annotations = IAnnotations(self.context)
 
+    security.declarePrivate('_get_jobs_queue')
+    def _get_jobs_queue(self):
+        if 'publisher-queue' not in self.annotations:
+            self.annotations['publisher-queue'] = zc.queue.Queue()
+        return self.annotations['publisher-queue']
+
     security.declarePrivate('getJobs')
     def getJobs(self):
         """
-        Returns a PersistentList of Job objects
+        Returns a list of Job objects
         @return:        job-objects
-        @rtype:         PersistentList
+        @rtype:         list
         """
-        if 'publisher-queue' not in self.annotations:
-            self.clearJobs()
-        return self.annotations['publisher-queue']
+        return self._get_jobs_queue()
 
     security.declarePrivate('clearJobs')
     def clearJobs(self):
         """
         Remove all jobs from the queue.
         """
-        self.annotations['publisher-queue'] = PersistentList()
+        queue = self._get_jobs_queue()
+        map(queue.pull, len(queue) * [0])
 
     security.declarePrivate('appendJob')
     def appendJob(self, job):
@@ -284,8 +290,8 @@ class Queue(object):
 
         if not isinstance(job, Job):
             raise TypeError('Excpected Job object')
-        list = self.getJobs()
-        list.append(job)
+
+        self._get_jobs_queue().put(job)
 
     security.declarePrivate('createJob')
     def createJob(self, *args, **kwargs):
@@ -313,8 +319,9 @@ class Queue(object):
         """
         if not isinstance(job, Job):
             raise TypeError('Excpected Job object')
-        list = self.getJobs()
-        list.remove(job)
+
+        queue = self._get_jobs_queue()
+        queue.pull(tuple(queue).index(job))
 
     security.declarePrivate('countJobs')
     def countJobs(self):
@@ -324,7 +331,7 @@ class Queue(object):
         @return:        Amount of jobs in the queue
         @rtype:         int
         """
-        return len(self.getJobs())
+        return len(self._get_jobs_queue())
 
     security.declarePrivate('popJob')
     def popJob(self):
@@ -334,7 +341,8 @@ class Queue(object):
         @return:        Oldest Job object
         @rtype:         Job
         """
-        return self.getJobs().pop(0)
+
+        return self._get_jobs_queue().pull()
 
     security.declarePrivate('_get_executed_jobs_storage')
     def _get_executed_jobs_storage(self):

--- a/ftw/publisher/sender/persistence.py
+++ b/ftw/publisher/sender/persistence.py
@@ -260,19 +260,16 @@ class Queue(object):
         @return:        job-objects
         @rtype:         PersistentList
         """
-        return self.annotations.get('publisher-queue', PersistentList())
+        if 'publisher-queue' not in self.annotations:
+            self.clearJobs()
+        return self.annotations['publisher-queue']
 
-    security.declarePrivate('_setJobs')
-    def _setJobs(self, list):
+    security.declarePrivate('clearJobs')
+    def clearJobs(self):
         """
-        Stores a PersistentList of Job objects
-        @param list:    list of jobs
-        @type list:     PersistentList
-        @return:        None
+        Remove all jobs from the queue.
         """
-        if not isinstance(list, PersistentList):
-            raise TypeError('Excpected PersistentList')
-        self.annotations['publisher-queue'] = list
+        self.annotations['publisher-queue'] = PersistentList()
 
     security.declarePrivate('appendJob')
     def appendJob(self, job):
@@ -289,7 +286,6 @@ class Queue(object):
             raise TypeError('Excpected Job object')
         list = self.getJobs()
         list.append(job)
-        self._setJobs(list)
 
     security.declarePrivate('createJob')
     def createJob(self, *args, **kwargs):
@@ -319,7 +315,6 @@ class Queue(object):
             raise TypeError('Excpected Job object')
         list = self.getJobs()
         list.remove(job)
-        self._setJobs(list)
 
     security.declarePrivate('countJobs')
     def countJobs(self):

--- a/ftw/publisher/sender/profiles/default/metadata.xml
+++ b/ftw/publisher/sender/profiles/default/metadata.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>2001</version>
 </metadata>

--- a/ftw/publisher/sender/tests/storage.txt
+++ b/ftw/publisher/sender/tests/storage.txt
@@ -31,7 +31,7 @@ Add a job for the folder
     <ftw.publisher.sender.persistence.Job object at ...>
     >>> queue.countJobs()
     1
-    >>> queue.getJobs()
+    >>> list(queue.getJobs())
     [<ftw.publisher.sender.persistence.Job object at ...>]
 
 Act as we just published the job

--- a/ftw/publisher/sender/upgrades/20160727152037_migrate_queue_to_zc_queue_tree/upgrade.py
+++ b/ftw/publisher/sender/upgrades/20160727152037_migrate_queue_to_zc_queue_tree/upgrade.py
@@ -1,0 +1,22 @@
+from DateTime import DateTime
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.progresslogger import ProgressLogger
+from random import random
+from zc.queue import Queue
+from zope.annotation.interfaces import IAnnotations
+
+
+class MigrateQueueToZCQueue(UpgradeStep):
+    """Migrate queue to zc.queue.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        annotations = IAnnotations(self.portal)
+
+        jobs = annotations.get('publisher-queue', ())
+        if hasattr(jobs, 'values'):
+            jobs = jobs.values()
+
+        queue = annotations['publisher-queue'] = Queue()
+        map(queue.put, ProgressLogger('Migrate jobs to new queue storage', jobs))

--- a/ftw/publisher/sender/upgrades/configure.zcml
+++ b/ftw/publisher/sender/upgrades/configure.zcml
@@ -2,7 +2,10 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     i18n_domain="ftw.publisher.sender">
+
+    <include package="ftw.upgrade" file="meta.zcml" />
 
     <!-- Remove annotations upgrade step -->
     <genericsetup:upgradeStep
@@ -66,5 +69,9 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <upgrade-step:directory
+        profile="ftw.publisher.sender:default"
+        directory="."
+        />
 
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(name='ftw.publisher.sender',
         'ftw.table',
         'ftw.upgrade',
         'z3c.form',
+        'zc.queue<2',
         'plone.z3cform',
         ],
 


### PR DESCRIPTION
Storing the jobs in a PersistentList object produces conflict errors
when two transactions add to the list, since PersistentList cannot
resolve those conflicting states.
Also BTrees have trouble to resolve such situations because usually the
buckets have conflicts, which seems unresolvable.

The zc.queue is implemented for exactly such situations and should
heavily reduce the appearance of write conflict errors.
