### PR TITLE
Add IPreventPublishing marker interface.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
+- Add IPreventPublishing marker interface. [jone]
+
 - Fix removeJob method, which always tried to remove the job from the worker queue.
   [mathias.leimgruber]
 

--- a/ftw/publisher/sender/browser/views.py
+++ b/ftw/publisher/sender/browser/views.py
@@ -5,6 +5,7 @@ from ftw.publisher.sender import message_factory as _
 from ftw.publisher.sender.events import AfterPushEvent, QueueExecutedEvent
 from ftw.publisher.sender.events import BeforeQueueExecutionEvent
 from ftw.publisher.sender.interfaces import IPathBlacklist, IConfig, IQueue
+from ftw.publisher.sender.interfaces import IPreventPublishing
 from ftw.publisher.sender.nojobs import publisher_jobs_are_disabled
 from ftw.publisher.sender.utils import add_transaction_aware_status_message
 from ftw.publisher.sender.utils import sendJsonToRealm
@@ -39,6 +40,9 @@ class PublishObject(BrowserView):
         @type kwargs:   dict
         @return:        Redirect to object`s default view
         """
+
+        if IPreventPublishing.providedBy(self.context):
+            return 'prevented'
 
         if publisher_jobs_are_disabled():
             return 'disabled'
@@ -97,6 +101,9 @@ class MoveObject(BrowserView):
         @return:        Redirect to object`s default view
         """
 
+        if IPreventPublishing.providedBy(self.context):
+            return 'prevented'
+
         if publisher_jobs_are_disabled():
             return 'disabled'
 
@@ -153,6 +160,9 @@ class DeleteObject(BrowserView):
         @type kwargs:   dict
         @return:        Redirect to object`s default view
         """
+
+        if IPreventPublishing.providedBy(self.context):
+            return 'prevented'
 
         if publisher_jobs_are_disabled():
             return 'disabled'

--- a/ftw/publisher/sender/configure.zcml
+++ b/ftw/publisher/sender/configure.zcml
@@ -26,6 +26,8 @@
     <include zcml:condition="installed ftw.lawgiver" file="lawgiver.zcml" />
     <include zcml:condition="have ftw.publisher.sender:taskqueue" package=".taskqueue" />
 
+    <interface interface=".interfaces.IPreventPublishing" />
+
     <adapter
           provides=".interfaces.IConfig"
           for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/ftw/publisher/sender/interfaces.py
+++ b/ftw/publisher/sender/interfaces.py
@@ -83,3 +83,9 @@ class IRealm(Interface):
     password = Password(
         title=_(u'label_realm_password',
                 u'Password'))
+
+
+class IPreventPublishing(Interface):
+    """Marker interface, which causes the publisher to
+    silently abort and never publish this object.
+    """

--- a/ftw/publisher/sender/tests/test_nojobs.py
+++ b/ftw/publisher/sender/tests/test_nojobs.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.publisher.sender.interfaces import IPreventPublishing
 from ftw.publisher.sender.interfaces import IQueue
 from ftw.publisher.sender.nojobs import publisher_jobs_disabled
 from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
@@ -41,3 +42,28 @@ class TestNoJobs(TestCase):
 
         page.restrictedTraverse('@@publisher.delete')()
         self.assertEquals(1, queue.countJobs())
+
+
+class TestPreventPublishing(TestCase):
+    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_publish(self):
+        page = create(Builder('page').providing(IPreventPublishing))
+        queue = IQueue(self.portal)
+        self.assertEquals(0, queue.countJobs())
+
+        page.restrictedTraverse('@@publisher.publish')()
+        self.assertEquals(0, queue.countJobs())
+
+    def test_delete(self):
+        page = create(Builder('page').providing(IPreventPublishing))
+        queue = IQueue(self.portal)
+        self.assertEquals(0, queue.countJobs())
+
+        page.restrictedTraverse('@@publisher.delete')()
+        self.assertEquals(0, queue.countJobs())


### PR DESCRIPTION
When the IPreventPublishing is provided by an object, any publisher
enqueuing attempts will be prevented.
This is useful for marking objects which should not be published at any
point.