### PR TITLE
Fix edge-case, if the published object is removed before the async wo…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix edge-case, if the published object is removed before the async worker collects the data from the object.
+  [mathias.leimgruber]
 
 
 2.7.0 (2016-08-16)

--- a/ftw/publisher/sender/taskqueue/queue.py
+++ b/ftw/publisher/sender/taskqueue/queue.py
@@ -1,8 +1,12 @@
 from collective.taskqueue import taskqueue
+from plone import api
 
 
 def enqueue_deferred_extraction(obj, action, filepath):
-    callback_path = '/'.join(obj.getPhysicalPath() +
+    callback_path = '/'.join(api.portal.get().getPhysicalPath() +
                              ('taskqueue_publisher_extract_object',))
+
+    path = '/'.join(obj.getPhysicalPath())
     taskqueue.add(callback_path, params={'action': action,
-                                         'filepath': filepath})
+                                         'filepath': filepath,
+                                         'path': path})

--- a/ftw/publisher/sender/taskqueue/worker.py
+++ b/ftw/publisher/sender/taskqueue/worker.py
@@ -1,15 +1,30 @@
+from ftw.publisher.sender import getLogger
 from ftw.publisher.sender.extractor import Extractor
+from plone import api
 from Products.Five.browser import BrowserView
+import os
 
 
 class PublisherExtractObject(BrowserView):
 
     def __call__(self):
+        logger = getLogger()
+
         action = self.request.form['action']
         filepath = self.request.form['filepath']
+        path = self.request.form['path']
+
+        obj = api.portal.get().unrestrictedTraverse(path, None)
+
+        if obj is None:
+            os.remove(filepath)
+            logger.warning(
+                'Removed "{0}", since the destination {1} no longer '
+                'exists'.format(filepath, path))
+            return 'JSON File "{0}" removed'.format(filepath)
 
         extractor = Extractor()
-        data = extractor(self.context, action)
+        data = extractor(obj, action)
 
         with open(filepath, 'w') as target:
             target.write(data)


### PR DESCRIPTION
…rker collects the data from the object.

In this case I removed the block on a contentpage before the worker gathered the data from the block. Instead of an empty json file, the json file is now removed.
<img width="944" alt="screen shot 2016-08-30 at 16 37 36" src="https://cloud.githubusercontent.com/assets/437933/18093526/733664c0-6ed0-11e6-8aeb-13ca7c1b1bd3.png">


And Publishing still works.
<img width="988" alt="screen shot 2016-08-30 at 16 37 53" src="https://cloud.githubusercontent.com/assets/437933/18093588/a4aea63e-6ed0-11e6-8ac0-c632f1ce24f7.png">
