### PR TITLE
Make moving to worker queue more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make moving to worker queue more robust. [jone]
 
 
 2.7.1 (2016-08-30)


### PR DESCRIPTION
- Only move to worker queue when we need more jobs there to process.
- Do not move all jobs, but only as many as we need.
- Commit transaction also when we stop moving at some point.

@maethu 