### PR TITLE
Close connection after publishing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Close connection after publishing. [jone]
 
 
 2.7.2 (2016-09-06)

--- a/ftw/publisher/sender/tests/utils.txt
+++ b/ftw/publisher/sender/tests/utils.txt
@@ -13,6 +13,8 @@ Mock the request:
     ...         self.headers = headers
     ...     def read(self):
     ...         return self
+    ...     def close(self):
+    ...         return self
     ...     def get_username_password(self):
     ...         cookies = dict([c.strip().split('=', 1) for c in
     ...                         self.headers.get('Cookie').split(

--- a/ftw/publisher/sender/utils.py
+++ b/ftw/publisher/sender/utils.py
@@ -98,7 +98,10 @@ def sendRequestToRealm(data, realm, serverAction):
         }
     request = urllib2.Request(url, urllib.urlencode(data), headers)
     response = urllib2.urlopen(request)
-    return response.read()
+    try:
+        return response.read()
+    finally:
+        response.close()
 
 
 def is_temporary(obj, checkId=True):


### PR DESCRIPTION
After publishing, we should close the connection when we've read the response.