### PR TITLE
Fix a bug where an old version was published.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.7.3 (unreleased)
 ------------------
 
+- Fix a bug where an old version was published. [jone]
+
 - Close connection after publishing. [jone]
 
 


### PR DESCRIPTION
When running the publisher with a redis taskqueue there was a bug where an old version was published because of a timing problem.

Depending on the sort order of the transaction data managers, the taskqueue TDM might receive the tpc_finish before the ZODB TDM, resulting in that the queue is actually processed a bit before the commit is in the ZODB.
This causes the worker to be executed on old state.

In order to mitigate this problem we now store a token in the annotations when the job is enqueued.
The token is also passed to the worker and is then verified in order to detect wrong states.
When we have a wrong state we retry by requeueing and aborting.
If it did not work for two times it is not the same problem and it will probably never be fixed automatically.

In order to avoid publishing the wrong state we abort with an exception.