### PR TITLE
No longer move simplelayout blocks instantly.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer move simplelayout blocks instantly. [jone]
 
 
 2.7.3 (2017-03-20)

--- a/ftw/publisher/sender/eventhandlers.py
+++ b/ftw/publisher/sender/eventhandlers.py
@@ -1,3 +1,4 @@
+from ftw.publisher.core.adapters.simplelayout_utils import is_sl_contentish
 from zope.component import queryMultiAdapter
 import os
 
@@ -8,6 +9,16 @@ def add_move_job(obj, event):
     """
 
     if os.environ.get('disable-publisher-for-testing', None):
+        return
+
+    if is_sl_contentish(obj):
+        # We are moving a simplelayout block, which is considered part
+        # of the content.
+        # A move of content should not be published instantly, but when
+        # the page is published.
+        # Since the simplelayout publisher adapter makes sure that blocks
+        # are removed when the content no longer exists on the backend,
+        # we can savely skip publishing block movements instantly.
         return
 
     if obj == event.object:

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(name='ftw.publisher.sender',
         'Products.CMFPlone',
 
         'ftw.autofeature',
-        'ftw.publisher.core',
+        'ftw.publisher.core >= 2.6.0',
         'ftw.table',
         'ftw.upgrade',
         'z3c.form',


### PR DESCRIPTION
Simplelayout blocks are considered part of the content and have no workflow for theirself.
Therefore we usually want to publish changes in the blocks along with the page.

But when cutting / pasting blocks from one page to another, these changes were instantly published, which was too early.

Since the simplelayout publisher adapter makes sure that blocks which no longer exist on the backend are removed from the frontend when publishing the parent page, we can stop moving simplelayout blocks instantly.

This improves the situation but does not solve all problems.
When I move a block from page A to page B, assuming both are in a redaction state, and then publish B first, the block will be removed from the published page A without having the page A updated to the backend state at this point.
@maethu I'm not sure if we should solve this issue and how we should solve this issue. Any thoughts?