### PR TITLE
add sanity checks for move job

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add sanity checks for move job. [tschanzt]
 
 
 2.7.4 (2017-04-27)

--- a/ftw/publisher/sender/extractor.py
+++ b/ftw/publisher/sender/extractor.py
@@ -1,4 +1,5 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from ZODB.POSException import ConflictError
 from ftw.publisher.core.interfaces import IDataCollector
@@ -57,22 +58,37 @@ class Extractor(object):
             move_data = getattr(self.object, 'event_information', None)
             #make data convertable and shrink amount of data
             #(replace objects by path)
-            del move_data['object']
-            portal_path = '/'.join(
-                self.object.portal_url.getPortalObject().getPhysicalPath())
-            new_parent_path = '/'.join(
-                move_data['newParent'].getPhysicalPath())
-            new_parent_rpath = new_parent_path[len(portal_path):]
+
+            url_tool = getToolByName(self.object, 'portal_url')
+            phys_root_path = url_tool.getPortalObject().getPhysicalPath()
+            portal_path = '/'.join(phys_root_path)
+
+            phys_new_parent_path = move_data['newParent'].getPhysicalPath()
+            new_parent_path = '/'.join(phys_new_parent_path)
+            new_parent_rpath = new_parent_path.replace(portal_path, '', 1)
+
+            phys_old_parent_path = move_data['oldParent'].getPhysicalPath()
+            old_parent_path = '/'.join(phys_old_parent_path)
+            old_parent_rpath = old_parent_path.replace(portal_path, '', 1)
+
+            self.checkPhysPaths(move_data,
+                                phys_root_path,
+                                phys_new_parent_path,
+                                phys_old_parent_path)
+
+            self.checkPaths(move_data, portal_path, new_parent_rpath,
+                            old_parent_rpath, new_parent_path, old_parent_path)
+
+            self.checkTraverse(move_data, new_parent_rpath)
+
             move_data['newParent'] = new_parent_rpath
-            old_parent_path = '/'.join(
-                move_data['oldParent'].getPhysicalPath())
-            old_parent_rpath = old_parent_path[len(portal_path):]
             move_data['oldParent'] = old_parent_rpath
+            del move_data['object']
+
             move_data['newTitle'] = self.object.Title().decode('utf-8')
             data['move'] = move_data
             # finally remove event_information from object
             delattr(self.object, 'event_information')
-
         # convert to json
         jsondata = self.convertToJson(data)
         return jsondata
@@ -163,3 +179,47 @@ class Extractor(object):
         data = decode_for_json(data)
 
         return json.dumps(data, sort_keys=True)
+
+    security.declarePrivate('checkPhysPaths')
+    def checkPhysPaths(self, payload, root_path, new_path, old_path):
+        min_depth = len(root_path)
+
+        if len(new_path) < min_depth:
+            raise ValueError("Physical path of "
+                             "new parent to short: {0} \n"
+                             "payload: {1}".format(
+                                 '/'.join(new_path), payload))
+
+        if len(old_path) < min_depth:
+            raise ValueError("Physical path of "
+                             "new parent to short: {0} \n"
+                             "payload: {1}".format(
+                                 '/'.join(old_path), payload))
+
+    security.declarePrivate('checkPaths')
+    def checkPaths(self, payload, root_path, new_rpath,
+                   old_rpath, new_path, old_path):
+        if not new_rpath.startswith('/'):
+            raise ValueError("either the Root Path or the new parent path "
+                             "are invalid \n root path: {0} \n "
+                             "new Parent path {1} \n"
+                             "payload: {2}".format(root_path,
+                                                   new_path,
+                                                   payload))
+
+        if not old_rpath.startswith('/'):
+            raise ValueError("Either the Root Path or the old parent path "
+                             "are invalid \n root path: {0} \n "
+                             "old Parent path {1} \n"
+                             "payload: {2}".format(root_path,
+                                                   old_path,
+                                                   payload))
+
+    security.declarePrivate('checkTraverse')
+    def checkTraverse(self, payload, new_rpath):
+        if payload['newParent'] != self.object.restrictedTraverse(
+                new_rpath.lstrip('/')):
+            raise ValueError("Couldn't get new Parent over "
+                             "restricted traverse. Path: {0} \n"
+                             "payload: {1}".format(
+                                 new_rpath, payload))


### PR DESCRIPTION
I added some checks to try and find corrupt move jobs. 
It does the following checks: 
 - Check if the physicalPath of the root is longer than of the parents. That obviously shouldn't be the case.
 - If we cut the path of the site root. Does it start with a `/` otherwise we raise since it isn't a valid path.
 - then we also check if we get the same object if we make a restrictedTraverse with the path for the new parent as we have in our dict.

Since we then raise and don't generate a json file I tried puting all necessary information in the Exception string. So the output would look something like this:
<img width="1420" alt="screen shot 2017-05-08 at 17 17 34" src="https://cloud.githubusercontent.com/assets/358342/25812054/64dcbf2c-3415-11e7-9a5c-5c940e77bbb1.png">
