### PR TITLE
Revert "add sanity checks for move job"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.6 (unreleased)
 ------------------
 
-- Add sanity checks for move job. [tschanzt]
+- Nothing changed yet.
 
 
 2.7.5 (2017-05-16)


### PR DESCRIPTION
Reverts the "add sanity checks for move job" changes from #45.
The changes were installed on a production deployment and reverted because the did more harm than good.
I'm reverting that in order to make new changes which we need to ship before this is resolved.

@mbaechtold could you reopen the original PR (rebased)?
/cc @tschanzt 