### PR TITLE
Fix extraction token access error on first publishing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix extraction token access error on first publishing. [jone]
 
 
 2.7.5 (2017-05-16)

--- a/ftw/publisher/sender/taskqueue/queue.py
+++ b/ftw/publisher/sender/taskqueue/queue.py
@@ -40,7 +40,7 @@ class PublisherExtractObjectWorker(BrowserView):
         obj = api.portal.get().unrestrictedTraverse(path, None)
 
         require_token = self.request.form['token']
-        current_token = IAnnotations(obj)[TOKEN_ANNOTATION_KEY]
+        current_token = IAnnotations(obj).get(TOKEN_ANNOTATION_KEY, None)
         if current_token != require_token:
             # The current version of the object is not the version we have
             # planned to extract.
@@ -56,11 +56,10 @@ class PublisherExtractObjectWorker(BrowserView):
 
             else:
                 raise Exception(
-                    'Unexpected version object version' +
+                    'Unexpected object version' +
                     ' after {!r} attempts.'.format(attempt) +
                     ' Required token: {!r},'.format(require_token) +
                     ' got token: {!r}'.format(current_token))
-
 
         if obj is None:
             os.remove(filepath)


### PR DESCRIPTION
The job of the extraction token is to invoke a retry of the job execution when the base transaction does not contain the changes which should be published.

This edge case can happen on slow systems when the taskqueue worker is faster than the ZODB, probably in combination with a multi instance setup.

The problem is that when publishing the object the first time, the token is not yet existing on the object when we have on old transaction. The keyword access caused a KeyError at this point.

Probably fixes #46