### PR TITLE
Fix extraction bug on move when redis is active.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix extraction bug on move when redis is active. [jone]
 
 
 2.7.6 (2017-06-08)

--- a/ftw/publisher/sender/eventhandlers.py
+++ b/ftw/publisher/sender/eventhandlers.py
@@ -22,9 +22,8 @@ def add_move_job(obj, event):
         return
 
     if obj == event.object:
-        data = event.__dict__.copy()
         # do nohting, if we are in portal_factory or the item is just created
-        if not data['oldName']:
+        if not event.oldName:
             return
         url_endswith = event.object.REQUEST.get('ACTUAL_URL') \
             .split('/')[-1:][0]
@@ -35,8 +34,7 @@ def add_move_job(obj, event):
                                 'object_paste']:
             return
         #set event info on
-        setattr(obj, 'event_information', data)
         move_view = queryMultiAdapter(
             (obj, obj.REQUEST),
             name="publisher.move")
-        move_view(no_response=True)
+        move_view(event, no_response=True)

--- a/ftw/publisher/sender/extractor.py
+++ b/ftw/publisher/sender/extractor.py
@@ -19,13 +19,15 @@ class Extractor(object):
     security = ClassSecurityInformation()
 
     security.declarePrivate('__call__')
-    def __call__(self, object, action):
+    def __call__(self, object, action, additional_data):
         """
         Extracts the required data (action dependent) from a object for
         creating a Job.
         @param object:      Plone Object to export data from
         @param action:      Action to perform [push|delete]
         @type action:       string
+        @param additional_data: Additional infos.
+        @type additional_data: dict
         @return:            data (json "encoded")
         @rtype:             string
         """
@@ -53,25 +55,7 @@ class Extractor(object):
                         del data['field_data_adapter'][field]
 
         if action == 'move':
-            #read out data from event_information attr
-            move_data = getattr(self.object, 'event_information', None)
-            #make data convertable and shrink amount of data
-            #(replace objects by path)
-            del move_data['object']
-            portal_path = '/'.join(
-                self.object.portal_url.getPortalObject().getPhysicalPath())
-            new_parent_path = '/'.join(
-                move_data['newParent'].getPhysicalPath())
-            new_parent_rpath = new_parent_path[len(portal_path):]
-            move_data['newParent'] = new_parent_rpath
-            old_parent_path = '/'.join(
-                move_data['oldParent'].getPhysicalPath())
-            old_parent_rpath = old_parent_path[len(portal_path):]
-            move_data['oldParent'] = old_parent_rpath
-            move_data['newTitle'] = self.object.Title().decode('utf-8')
-            data['move'] = move_data
-            # finally remove event_information from object
-            delattr(self.object, 'event_information')
+            data['move'] = additional_data['move_data']
 
         # convert to json
         jsondata = self.convertToJson(data)

--- a/ftw/publisher/sender/tests/__init__.py
+++ b/ftw/publisher/sender/tests/__init__.py
@@ -1,1 +1,16 @@
-#
+from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+import transaction
+
+
+class FunctionalTestCase(TestCase):
+    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def grant(self, *roles):
+        setRoles(self.portal, TEST_USER_ID, list(roles))
+        transaction.commit()

--- a/ftw/publisher/sender/tests/test_extractor.py
+++ b/ftw/publisher/sender/tests/test_extractor.py
@@ -19,7 +19,7 @@ class TestExtractor(PloneTestCase):
             id='topic1', title='topic 1')
         self.topic1 = getattr(self.folder, topicid, None)
         self.extractor = Extractor()
-        self.extractor(self.testdoc1, 'delete')
+        self.extractor(self.testdoc1, 'delete', {})
 
     def test_extractor_object(self):
         adapters = getAdapters((self.testdoc1, ), IDataCollector)
@@ -71,7 +71,7 @@ class TestExtractor(PloneTestCase):
 
     def test_ignoreFields(self):
         # first all fields are in data
-        jsondata = self.extractor(self.testdoc1, 'push')
+        jsondata = self.extractor(self.testdoc1, 'push', {})
         # decode from json
         data = json.loads(jsondata)
         data = encode_after_json(data)
@@ -84,7 +84,7 @@ class TestExtractor(PloneTestCase):
         config.set_ignored_fields({'Document': ['description',
                                                 'excludeFromNav']})
 
-        jsondata = self.extractor(self.testdoc1, 'push')
+        jsondata = self.extractor(self.testdoc1, 'push', {})
         # decode from json
         data = json.loads(jsondata)
         data = encode_after_json(data)

--- a/ftw/publisher/sender/tests/test_move.py
+++ b/ftw/publisher/sender/tests/test_move.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.publisher.sender.interfaces import IQueue
+from ftw.publisher.sender.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from ftw.testing import freeze
+from ftw.testing import staticuid
+import json
+
+
+class TestMove(FunctionalTestCase):
+
+    @browsing
+    @staticuid()
+    def test_moving_object_job_data(self, browser):
+        self.grant('Manager')
+        source = create(Builder('folder').titled(u'Source'))
+        target = create(Builder('folder').titled(u'Target'))
+        with freeze(datetime(2018, 1, 2, 3, 4, 5)):
+            page = create(Builder('page').titled('The Page').within(source))
+
+        self.assertEquals(0, IQueue(self.portal).countJobs())
+        browser.login().open(page).click_on('Cut').open(target).click_on('Paste')
+        statusmessages.assert_message(
+            'Object move/rename action has been added to the queue.')
+
+        self.assertEquals(1, IQueue(self.portal).countJobs())
+
+        job, = IQueue(self.portal).getJobs()
+        self.assertEquals('move', job.action)
+        data = job.getData()
+        self.assertTrue(data)
+
+        self.maxDiff = None
+        self.assertEquals(
+            {u'utf8:metadata': {
+                u'utf8:UID': u'utf8:testmovingobjectjobdata000000003',
+                u'utf8:action': u'utf8:move',
+                u'utf8:id': u'utf8:the-page',
+                u'utf8:modified': u'utf8:2018/01/02 03:04:05 GMT+1',
+                u'utf8:physicalPath': u'utf8:/target/the-page',
+                u'utf8:portal_type': u'utf8:Document',
+                u'utf8:review_state': u'utf8:',
+                u'utf8:schema_path': u'utf8:Products.ATContentTypes.content.document.ATDocument.schema',
+                u'utf8:sibling_positions': {u'utf8:the-page': 0}},
+             u'utf8:move': {
+                 u'utf8:newName': u'utf8:the-page',
+                 u'utf8:newParent': u'utf8:/target',
+                 u'utf8:newTitle': u'unicode:The Page',
+                 u'utf8:oldName': u'utf8:the-page',
+                 u'utf8:oldParent': u'utf8:/source'}},
+            json.loads(data))

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ tests_require = [
     'plone.app.testing',
     'Products.PloneTestCase',
     'ftw.testing [splinter]',
+    'ftw.testbrowser',
     'ftw.lawgiver',
     'ftw.builder',
     'ftw.contentpage',


### PR DESCRIPTION
When redis is active for deferred extraction in a multi instance setup, the move job may contain invalid paths when the extraction job is processed in a different process than the one the job was created.

The problem is that the event infos are stored on the object until the extraction happened. Since the event infos contain acquisition wrapped objects and the deferreing results in that the extraction happens in a different transaction, it caused persistent pointers to be stored in the database.
The extraction did rely on having acquisition wrapped objects, which was sometimes not the case, depending on the database cache state.

The solution is to not store anything but prepare strings early.
The event infos are now stored in an `additional_data` dict on the job, so that it can be reused on extration time.
Since the deferred extraction has no reference to the job object, the infos are passed to the worker as serialized json.

Since there was no move test at all I added one testing the extracted result. It did work before my changes, my changes did not change the result.
I have reproduced the issue in a multi instance redis setup reliably and could profe that this change fixes the problem by inspecting the paths in the extracted JSON file; they are now the correct relative paths.
I have verified that the move extraction with redis still works with this changes.

This closes #49 because it fixes this issue; relates to #45, #47.