### PR TITLE
Fix extraction error when retrying.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug when retrying extraction, introduced in 2.7.7. [jone]
 
 
 2.7.7 (2017-06-09)

--- a/ftw/publisher/sender/taskqueue/queue.py
+++ b/ftw/publisher/sender/taskqueue/queue.py
@@ -56,7 +56,7 @@ class PublisherExtractObjectWorker(BrowserView):
                 # early and the transaction which triggered the action was not
                 # yet commited to the database.
                 return enqueue_deferred_extraction(
-                    obj, action, filepath,
+                    obj, action, filepath, additional_data,
                     attempt=attempt + 1,
                     token=require_token)
 


### PR DESCRIPTION
In 2.7.7 we introduced the additional data argument to the extraction.
The change did not make it into the extraction retry code.