### PR TITLE
Rewrite tests using "ftw.testbrowser".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.7.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Rewrite tests using "ftw.testbrowser", drop dependency on
+  "ftw.testing[splinter]". [mbaechtold]
 
 
 2.7.8 (2017-06-12)

--- a/ftw/publisher/sender/testing.py
+++ b/ftw/publisher/sender/testing.py
@@ -2,7 +2,7 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testing import ComponentRegistryLayer
-from ftw.testing import FunctionalSplinterTesting
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
@@ -67,7 +67,7 @@ PUBLISHER_SENDER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(PUBLISHER_SENDER_FIXTURE,),
     name="ftw.publisher.sender:integration")
 
-PUBLISHER_SENDER_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+PUBLISHER_SENDER_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(PUBLISHER_SENDER_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="ftw.publisher.sender:functional")

--- a/ftw/publisher/sender/tests/builders.py
+++ b/ftw/publisher/sender/tests/builders.py
@@ -2,25 +2,7 @@ from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.dexterity import DexterityBuilder
 import ftw.simplelayout.tests.builders
-
-
-class ContentPageBuilder(ArchetypesBuilder):
-
-    portal_type = 'ContentPage'
-
-builder_registry.register('content page', ContentPageBuilder)
-
-
-class TextBlockBuilder(ArchetypesBuilder):
-    portal_type = 'TextBlock'
-
-builder_registry.register('text block', TextBlockBuilder)
-
-
-class ListingBlockBuilder(ArchetypesBuilder):
-    portal_type = 'ListingBlock'
-
-builder_registry.register('listing block', ListingBlockBuilder)
+import ftw.contentpage.tests.builders
 
 
 class ExampleDxTypeBuilder(DexterityBuilder):

--- a/ftw/publisher/sender/tests/pages.py
+++ b/ftw/publisher/sender/tests/pages.py
@@ -1,37 +1,39 @@
-from ftw.testing import browser
-from ftw.testing.pages import Plone
+from ftw.testbrowser import browser as default_browser
+from ftw.testbrowser.pages import statusmessages
 
 
-class Workflow(Plone):
+class Workflow(object):
+
+    def __init__(self, browser=default_browser):
+        self.browser = browser
 
     def get_status(self):
-        locals()['__traceback_info__'] = browser().url
-        elm = browser().find_by_xpath(
+        locals()['__traceback_info__'] = self.browser.url
+        elm = self.browser.xpath(
             '//span[starts-with(@class, "state-")]')
         assert elm, 'Could not find element containg current status'
         return elm.first.text
 
     def assert_status(self, status):
-        locals()['__traceback_info__'] = browser().url
+        locals()['__traceback_info__'] = self.browser.url
         current_status = self.get_status()
         assert status == current_status, \
             'Expected workflow state "%s" but it is "%s"' % (
             status, current_status)
 
     def do_transition(self, label, assert_success=True):
-        locals()['__traceback_info__'] = browser().url
-        elements = browser().find_by_xpath(
+        locals()['__traceback_info__'] = self.browser.url
+        elements = self.browser.xpath(
             '//a[starts-with(@id, "workflow-transition-")]')
-
         assert elements, 'No workflow transitions available.'
 
         links = {}
         for node in elements:
-            links[self.normalize_whitespace(node.text)] = node
+            links[node.text] = node
 
         assert label in links, 'Could not find transition "%s", got %s' % (
             label, links.keys())
 
         links[label].click()
         if assert_success:
-            self.assert_portal_message('info', 'Item state changed.')
+            statusmessages.assert_message('Item state changed.')

--- a/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
+++ b/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
@@ -1,15 +1,11 @@
-from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
+from ftw.publisher.sender.tests import FunctionalTestCase
 from ftw.publisher.sender.tests.pages import Workflow
-from ftw.testing.pages import Plone
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
 from plone.uuid.interfaces import IUUID
-from unittest2 import TestCase
+from Products.CMFCore.utils import getToolByName
 import transaction
 
 
@@ -19,97 +15,101 @@ EXAMPLE_WF_PUBLISHED = 'publisher-example-workflow--STATUS--published'
 EXAMPLE_WF_REVISION = 'publisher-example-workflow--STATUS--revision'
 
 
-class TestExampleWFConstraintDefinition(TestCase):
+class TestExampleWFConstraintDefinition(FunctionalTestCase):
 
-    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
 
     def setUp(self):
-        self.portal = self.layer['portal']
-        self.request = self.layer['request']
-
-        setRoles(self.portal, TEST_USER_ID, ['Manager', 'Reviewer'])
-        login(self.portal, TEST_USER_NAME)
+        super(TestExampleWFConstraintDefinition, self).setUp()
+        self.grant('Manager')
 
         wftool = getToolByName(self.portal, 'portal_workflow')
         wftool.setChainForPortalTypes(['Document', 'Folder', 'ContentPage'],
                                       EXAMPLE_WF_ID)
 
         transaction.commit()
-
-    def test_warning_on_submit_when_parent_is_not_published(self):
+        
+    @browsing
+    def test_warning_on_submit_when_parent_is_not_published(self, browser):
         folder = create(Builder('folder')
                         .in_state(EXAMPLE_WF_INTERNAL))
         page = create(Builder('page')
                       .within(folder)
                       .in_state(EXAMPLE_WF_INTERNAL))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('submit')
 
-        Workflow().assert_portal_message(
-            'warning', 'The parent object needs to be published first.')
+        statusmessages.assert_message('The parent object needs to be published first.')
         Workflow().assert_status('Pending')
 
-    def test_error_on_publish_when_parent_is_not_published(self):
+    @browsing
+    def test_error_on_publish_when_parent_is_not_published(self, browser):
         folder = create(Builder('folder')
                         .in_state(EXAMPLE_WF_INTERNAL))
         page = create(Builder('page')
                       .within(folder)
                       .in_state(EXAMPLE_WF_INTERNAL))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish', assert_success=False)
 
-        Workflow().assert_portal_message(
-            'error', 'The parent object needs to be published first.')
+        statusmessages.assert_message('The parent object needs to be published first.')
         Workflow().assert_status('Internal')
 
-    def test_no_error_when_parent_is_in_revision(self):
+    @browsing
+    def test_no_error_when_parent_is_in_revision(self, browser):
         folder = create(Builder('folder')
                         .in_state(EXAMPLE_WF_REVISION))
         page = create(Builder('page')
                       .within(folder)
                       .in_state(EXAMPLE_WF_REVISION))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
         Workflow().assert_status('Published')
 
-    def test_warning_on_retract_when_children_published(self):
+    @browsing
+    def test_warning_on_retract_when_children_published(self, browser):
         folder = create(Builder('folder')
                         .in_state(EXAMPLE_WF_PUBLISHED))
         page = create(Builder('page')
                       .within(folder)
                       .in_state(EXAMPLE_WF_PUBLISHED))
 
-        Plone().login().visit(folder)
+        browser.login().visit(folder)
         Workflow().do_transition('retract')
 
-        Workflow().assert_portal_message(
-            'warning', 'The child object <a href="http://nohost/plone'
-            '/folder/document"></a> is still published.')
+        statusmessages.assert_message(
+            'The child object <a href="http://nohost/plone'
+            '/folder/document"></a> is still published.'
+        )
         Workflow().assert_status('Internal')
 
-        Workflow().visit(page).assert_status('Published')
+        browser.visit(page)
+        Workflow().assert_status('Published')
 
-    def test_warning_when_child_is_in_revision(self):
+    @browsing
+    def test_warning_when_child_is_in_revision(self, browser):
         folder = create(Builder('folder')
                         .in_state(EXAMPLE_WF_PUBLISHED))
         page = create(Builder('page')
                       .within(folder)
                       .in_state(EXAMPLE_WF_REVISION))
 
-        Plone().login().visit(folder)
+        browser.login().visit(folder)
         Workflow().do_transition('retract')
 
-        Workflow().assert_portal_message(
-            'warning', 'The child object <a href="http://nohost/plone'
-            '/folder/document"></a> is still published.')
+        statusmessages.assert_message(
+            'The child object <a href="http://nohost/plone'
+            '/folder/document"></a> is still published.'
+        )
         Workflow().assert_status('Internal')
 
-        Workflow().visit(page).assert_status('Revision')
+        browser.visit(page)
+        Workflow().assert_status('Revision')
 
-    def test_warning_on_publish_when_references_are_not_published(self):
+    @browsing
+    def test_warning_on_publish_when_references_are_not_published(self, browser):
         page = create(Builder('page')
                       .titled('The Page'))
         other_page = create(Builder('page')
@@ -117,14 +117,16 @@ class TestExampleWFConstraintDefinition(TestCase):
         page.setRelatedItems(other_page)
         transaction.commit()
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
+        statusmessages.assert_message(
+            'The referenced object <a href="http://nohost/plone'
+            '/the-other-page">The Other Page</a> is not yet published.'
+        )
 
-        Workflow().assert_portal_message(
-            'warning', 'The referenced object <a href="http://nohost/plone'
-            '/the-other-page">The Other Page</a> is not yet published.')
 
-    def test_do_not_fail_if_reference_is_none(self):
+    @browsing
+    def test_do_not_fail_if_reference_is_none(self, browser):
         page = create(Builder('page')
                       .titled('The Page'))
         other_page = create(Builder('page')
@@ -134,13 +136,12 @@ class TestExampleWFConstraintDefinition(TestCase):
         self.portal._delObject(other_page.getId(), suppress_events=True)
         transaction.commit()
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
-        self.assertFalse(len(Workflow().portal_messages()['warning']),
-                         'No waring expected, since the ref does not exists '
-                         'anymore.')
+        statusmessages.assert_no_error_messages()
 
-    def test_warning_on_publish_when_sl_block_has_unpublished_references(self):
+    @browsing
+    def test_warning_on_publish_when_sl_block_has_unpublished_references(self, browser):
         page=create(Builder('content page'))
         other_page=create(Builder('content page').titled('Other Page'))
         other_page_uuid=IUUID(other_page)
@@ -148,14 +149,16 @@ class TestExampleWFConstraintDefinition(TestCase):
                .having(text='<a href="resolveuid/%s">link</a>' % other_page_uuid)
                .within(page))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
 
-        Workflow().assert_portal_message(
-            'warning', 'The referenced object <a href="http://nohost/plone'
-            '/other-page">Other Page</a> is not yet published.')
+        statusmessages.assert_message(
+            'The referenced object <a href="http://nohost/plone'
+            '/other-page">Other Page</a> is not yet published.'
+        )
 
-    def test_warning_on_retract_when_references_are_still_published(self):
+    @browsing
+    def test_warning_on_retract_when_references_are_still_published(self, browser):
         page=create(Builder('page')
                       .titled('The Page')
                       .in_state(EXAMPLE_WF_PUBLISHED))
@@ -165,14 +168,16 @@ class TestExampleWFConstraintDefinition(TestCase):
         page.setRelatedItems(other_page)
         transaction.commit()
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('retract')
 
-        Workflow().assert_portal_message(
-            'warning', 'The referenced object <a href="http://nohost/plone'
-            '/the-other-page">The Other Page</a> is still published.')
+        statusmessages.assert_message(
+            'The referenced object <a href="http://nohost/plone'
+            '/the-other-page">The Other Page</a> is still published.'
+        )
 
-    def test_warning_on_retract_when_sl_block_has_published_references(self):
+    @browsing
+    def test_warning_on_retract_when_sl_block_has_published_references(self, browser):
         page=create(Builder('content page'))
         other_page=create(Builder('content page')
                             .titled('Other Page')
@@ -182,11 +187,12 @@ class TestExampleWFConstraintDefinition(TestCase):
                .having(text='<a href="resolveuid/%s">link</a>' % other_page_uuid)
                .within(page))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         # cannot add text block when published
         Workflow().do_transition('publish')
         Workflow().do_transition('retract')
 
-        Workflow().assert_portal_message(
-            'warning', 'The referenced object <a href="http://nohost/plone'
-            '/other-page">Other Page</a> is still published.')
+        statusmessages.assert_message(
+            'The referenced object <a href="http://nohost/plone'
+            '/other-page">Other Page</a> is still published.'
+        )

--- a/ftw/publisher/sender/tests/test_simplelayout.py
+++ b/ftw/publisher/sender/tests/test_simplelayout.py
@@ -1,23 +1,16 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.publisher.sender.interfaces import IQueue
-from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
+from ftw.publisher.sender.tests import FunctionalTestCase
 from ftw.publisher.sender.tests.pages import Workflow
 from ftw.simplelayout.configuration import flattened_block_uids
 from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.testbrowser import browsing
 from ftw.testing import staticuid
-from ftw.testing.pages import Plone
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
 from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
 
 
-class TestPublishingSimplelayoutTypes(TestCase):
-
-    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
+class TestPublishingSimplelayoutTypes(FunctionalTestCase):
 
     portal_type = 'ContentPage'
     page_builder = 'content page'
@@ -26,20 +19,18 @@ class TestPublishingSimplelayoutTypes(TestCase):
 
     def setUp(self):
         super(TestPublishingSimplelayoutTypes, self).setUp()
-
-        self.portal = self.layer['portal']
-        setRoles(self.portal, TEST_USER_ID, ['Manager'])
-        login(self.portal, TEST_USER_NAME)
+        self.grant('Manager')
 
         wftool = getToolByName(self.portal, 'portal_workflow')
         wftool.setChainForPortalTypes([self.portal_type],
                                       'publisher-example-workflow')
 
-    def test_blocks_are_published_with_contentpage(self):
+    @browsing
+    def test_blocks_are_published_with_contentpage(self, browser):
         page = create(Builder(self.page_builder))
         create(Builder(self.textblock_builder).within(page))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
 
         queue = IQueue(self.portal)
@@ -47,12 +38,13 @@ class TestPublishingSimplelayoutTypes(TestCase):
             2, queue.countJobs(),
             'Expected the page and the text block to be in the queue.')
 
-    def test_sl_listing_block_publishes_its_children(self):
+    @browsing
+    def test_sl_listing_block_publishes_its_children(self, browser):
         page = create(Builder(self.page_builder))
         listing_block = create(Builder(self.listingblock_builder).within(page))
         create(Builder('file').within(listing_block))
 
-        Plone().login().visit(page)
+        browser.login().visit(page)
         Workflow().do_transition('publish')
 
         queue = IQueue(self.portal)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_require = [
     'plone.app.relationfield',
     'plone.app.testing',
     'Products.PloneTestCase',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'ftw.testbrowser',
     'ftw.lawgiver',
     'ftw.builder',


### PR DESCRIPTION
This is needed because "ftw.testing" 1.12.0 removed the "splinter" extra.