### PR TITLE
Fix retrying extraction of move jobs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.7.9 (unreleased)
 ------------------
 
+- Fix retrying extraction of move jobs. [mathias.leimgruber]
+
 - Rewrite tests using "ftw.testbrowser", drop dependency on
   "ftw.testing[splinter]". [mbaechtold]
 


### PR DESCRIPTION
Fix move/rename data extracton:
Getting the object with the new path may be not possible, since the transaction is no yet committed. 
