### PR TITLE
Make the WorkflowConfigTest base class importable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 2.7.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Make the WorkflowConfigTest base class importable again without
+  installing the tests extras. [jone]
 
 2.7.9 (2017-07-25)
 ------------------

--- a/ftw/publisher/sender/tests/__init__.py
+++ b/ftw/publisher/sender/tests/__init__.py
@@ -1,4 +1,3 @@
-from ftw.publisher.sender.testing import PUBLISHER_SENDER_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from unittest2 import TestCase
@@ -6,7 +5,22 @@ import transaction
 
 
 class FunctionalTestCase(TestCase):
-    layer = PUBLISHER_SENDER_FUNCTIONAL_TESTING
+
+    @property
+    def layer(self):
+        """The testing layer is implemented as a property so that we can defer the
+        layer import.
+
+        This is important for packages depending on ftw.publisher.sender and using
+        the WorkflowConfigTest-class as superclass, without installing
+        ftw.publisher.sender's tests-extras.
+
+        If the layer import would be on module level, we would load the testing.py,
+        which would import from ftw.contentpage builders and other dependencies
+        which may not be installed.
+        """
+        from ftw.publisher.sender import testing
+        return testing.PUBLISHER_SENDER_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']


### PR DESCRIPTION
The WorkflowConfigTest is used by depending packages for automatically testing their workflow config. It must be importable from outside.

Because tests packages __init__ module imported from the testing layer, the WorkflowConfigTest class was not importable without installing ftw.publisher.sender[tests], including packages such asftw.contentpage.

Installing this extras brings in opinionated packages, a policy should not have to do that.

By moving the layer import into a property we can make it possible to use the WorkflowConfigTest without installing the tests extras.