### PR TITLE
Make renaming objects on the Plone Site work again.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make renaming objects on the Plone Site work again. [mbaechtold]
 
 
 2.7.10 (2017-07-27)

--- a/ftw/publisher/sender/utils.py
+++ b/ftw/publisher/sender/utils.py
@@ -136,8 +136,4 @@ def get_site_relative_path(obj):
     obj_path = '/'.join(obj.getPhysicalPath())
     portal_path = '/'.join(portal.getPhysicalPath())
 
-    assert obj_path.startswith(portal_path + '/'), \
-        'Object with path {!r} must be within portal {!r}'.format(
-            obj_path, portal_path)
-
     return obj_path[len(portal_path):]


### PR DESCRIPTION
The assert statement's condition did not support the case when the `obj` is the site root. This situation can happen when renaming objects on the site root.

The condition's job was to erify that objects actually are stored within the portal. But since the portal object is found by walking up the object acquisition chain, we are already sure that the object is stored within the portal object. Therefore the assertion is dumb, unnecessary and wrong.