### PR TITLE
Make ftw.contentpage dependency optional for other packages.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.7.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make ftw.contentpage dependency optional for other packages.
+  [mathias.leimgruber]
 
 
 2.7.11 (2017-10-03)

--- a/ftw/publisher/sender/tests/builders.py
+++ b/ftw/publisher/sender/tests/builders.py
@@ -2,7 +2,13 @@ from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.dexterity import DexterityBuilder
 import ftw.simplelayout.tests.builders
-import ftw.contentpage.tests.builders
+
+
+try:
+    import ftw.contentpage.tests.builders
+except ImportError:
+    # Don't bother about ftw.contentpage, since it's a legay package.
+    pass
 
 
 class ExampleDxTypeBuilder(DexterityBuilder):


### PR DESCRIPTION
I don't want install ftw.contentpage for integration tests in other packages, which actually does not use ftw.contentpage.

> Also it's a legacy package, we may drop this integration. 

Not sure yet 😄 