### PR TITLE
Execute move jobs synchronously, instead of asynchronously.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Execute move jobs synchronously, instead of asynchronously. [mbaechtold]
 
 
 2.7.11 (2017-10-03)

--- a/ftw/publisher/sender/persistence.py
+++ b/ftw/publisher/sender/persistence.py
@@ -617,7 +617,7 @@ class Job(Persistent):
             open(file, 'w').close()  # touch
             from ftw.publisher.sender.taskqueue import queue
 
-            if self.action != 'delete':
+            if self.action not in ['delete', 'move']:
                 queue.enqueue_deferred_extraction(object, self.action, file,
                                                   self.additional_data)
             else:


### PR DESCRIPTION
We expect less 0 bytes move jobs with this change.