### PR TITLE
Improve extraction worker.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.7.14 (unreleased)
 -------------------
 
+- Improve extraction worker. [mbaechtold]
+
 - Add support for Plone 5.1. [mbaechtold]
 
 


### PR DESCRIPTION
The extraction used to crash during the asynchronous extraction when the object does not exist on the given path.

This made the worker step into the special handling of move jobs although it's not a move job (the move jobs are processed synchronously, instead of asynchronously since 2.7.12).