### PR TITLE
Extraction: increase attempts and pause in between.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Extraction: increase attempts to 10 and pause 0.5s in between. [jone]
 
 2.8.0 (2018-04-25)
 ------------------


### PR DESCRIPTION
In a multi zeo-client setup with redis, other processes may execute the extraction jobs. Since Redis can store the jobs in RAM while the ZODB needs to write to disk, the job may be executed by another process before the ZODB transaction is written to the database.

We have seen situations in the wild where a simple retry was still too fast. This probably heavily depends on the balancing of the hardware components and the virtualization settings.

In order to be more robust for such situations we increase the maximum extraction attempts to 10 and also make a pause of 0.5s between each attempt, waiting 5s max per job.

The sleep is happening when executing the extraction job in the async thread and thus does not block users.