### PR TITLE
Do not warn unpublished references which will now be published.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Do not warn unpublished references which will now be published. [jone]
 
 2.8.1 (2018-09-17)
 ------------------

--- a/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
+++ b/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
@@ -34,7 +34,7 @@ class TestExampleWFConstraintDefinition(FunctionalTestCase):
                                       EXAMPLE_WF_ID)
 
         transaction.commit()
-        
+
     @browsing
     def test_warning_on_submit_when_parent_is_not_published(self, browser):
         folder = create(Builder('folder')
@@ -130,6 +130,32 @@ class TestExampleWFConstraintDefinition(FunctionalTestCase):
             '/the-other-page">The Other Page</a> is not yet published.'
         )
 
+    @browsing
+    def test_warning_shown_when_referencing_children_with_separate_workflow(self, browser):
+        parent = create(Builder('folder').titled(u'Parent'))
+        child = create(Builder('folder').titled(u'Child').within(parent))
+        helpers.set_related_items(parent, child)
+
+        browser.login().visit(parent)
+        Workflow().do_transition('publish')
+        self.assertItemsEqual(
+            ['The referenced object <a href="http://nohost/plone'
+             '/parent/child">Child</a> is not yet published.'],
+            statusmessages.warning_messages(),
+        )
+
+    @browsing
+    def test_warning_not_shown_when_referencing_children_without_workflow(self, browser):
+        parent = create(Builder('folder').titled(u'Parent'))
+        child = create(Builder('file').titled(u'Child').within(parent))
+        helpers.set_related_items(parent, child)
+
+        browser.login().visit(parent)
+        Workflow().do_transition('publish')
+        self.assertItemsEqual(
+            [],
+            statusmessages.warning_messages(),
+        )
 
     @browsing
     def test_do_not_fail_if_reference_is_none(self, browser):


### PR DESCRIPTION
When publishing a container which has a reference to a child which does not have a workflow and thus will probably be published along with the container, we should not warn the user about unpublished references.