### PR TITLE
Fix Plone 5 tests.

### DIFF
--- a/ftw/publisher/sender/tests/test_move.py
+++ b/ftw/publisher/sender/tests/test_move.py
@@ -36,21 +36,26 @@ class TestMove(FunctionalTestCase):
 
         self.maxDiff = None
 
-        expected = {u'utf8:metadata': {
-            u'utf8:UID': u'utf8:testmovingobjectjobdata000000003',
-            u'utf8:action': u'utf8:move',
-            u'utf8:id': u'utf8:the-page',
-            u'utf8:modified': u'utf8:2018/01/02 03:04:05 GMT+1',
-            u'utf8:physicalPath': u'utf8:/target/the-page',
-            u'utf8:portal_type': u'utf8:Document',
-            u'utf8:review_state': u'utf8:',
-            u'utf8:sibling_positions': {u'utf8:the-page': 0}},
-         u'utf8:move': {
-             u'utf8:newName': u'utf8:the-page',
-             u'utf8:newParent': u'utf8:/target',
-             u'utf8:newTitle': u'unicode:The Page',
-             u'utf8:oldName': u'utf8:the-page',
-             u'utf8:oldParent': u'utf8:/source'}}
+        expected = {
+            u'utf8:metadata': {
+                u'utf8:UID': u'utf8:testmovingobjectjobdata000000003',
+                u'utf8:action': u'utf8:move',
+                u'utf8:id': u'utf8:the-page',
+                u'utf8:modified': u'utf8:2018/01/02 03:04:05 GMT+1',
+                u'utf8:physicalPath': u'utf8:/target/the-page',
+                u'utf8:portal_type': u'utf8:Document',
+                u'utf8:review_state': u'utf8:',
+                u'utf8:sibling_positions': {u'utf8:the-page': 0}},
+            u'utf8:move': {
+                u'utf8:newName': u'utf8:the-page',
+                u'utf8:newParent': u'utf8:/target',
+                u'utf8:newTitle': u'unicode:The Page',
+                u'utf8:oldName': u'utf8:the-page',
+                u'utf8:oldParent': u'utf8:/source'}}
+
+        if IS_AT_LEAST_PLONE_5_1:
+            expected[u'utf8:metadata'][u'utf8:modified'] = u'utf8:{}'.format(
+                str(page.modified()).decode('utf-8'))
 
         self.assertEquals(
             expected,


### PR DESCRIPTION
It seems that the modification date is not frozen. Workaround: use the actual timestamp.