### PR TITLE
Add plone.protect support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support CSRF protection and fix publishing on plone 5 with it [Nachtalb]
 
 
 2.10.0 (2019-10-18)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Support CSRF protection and fix publishing on plone 5 with it [Nachtalb]
+- Fix realm editing form [Nachtalb]
 
 
 2.10.0 (2019-10-18)

--- a/ftw/publisher/sender/browser/exectued_list_actions.pt
+++ b/ftw/publisher/sender/browser/exectued_list_actions.pt
@@ -1,0 +1,21 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="ftw.publisher.sender">
+
+  <body>
+    <form tal:attributes="action string:@@publisher-config-listExecutedJobs" method="POST" tal:define="key options/key">
+      <a class="standalone"
+         tal:attributes="href string:@@publisher-config-executed-job-details?job=${key}"
+         i18n:translate="link_job_details">
+        Details
+      </a>
+      |
+      <input type="hidden" name="requeue.job" tal:attributes="value key" />
+      <button type="submit" i18n:translate="link_requeue_job">
+        Requeue
+      </button>
+      <span tal:replace="structure context/@@authenticator/authenticator"/>
+    </form>
+  </body>
+</html>

--- a/ftw/publisher/sender/browser/listJobs.pt
+++ b/ftw/publisher/sender/browser/listJobs.pt
@@ -50,12 +50,20 @@
                 <td tal:define="length job/getSize"
                     tal:content="string:${length} Bytes"/>
                 <td>
-                  <a tal:attributes="href string:./@@publisher.execute.job?job=${job/get_filename}"
-                     i18n:translate="execute_job"
-                     >Execute</a>
-                  |
-                  <a tal:attributes="href string:./@@publisher.remove.job?job=${job/get_filename}"
-                     i18n:translate="delete_job">Delete</a>
+                  <form action="@@publisher.execute.job" method="POST">
+                    <input type="hidden" name="job" tal:attributes="value job/get_filename" />
+                    <button type="submit" i18n:translate="execute_job">
+                      Execute
+                    </button>
+                    <span tal:replace="structure context/@@authenticator/authenticator"/>
+                  </form>
+                  <form action="@@publisher.remove.job" method="POST">
+                    <input type="hidden" name="job" tal:attributes="value job/get_filename" />
+                    <button type="submit" i18n:translate="delete_job">
+                      Delete
+                    </button>
+                    <span tal:replace="structure context/@@authenticator/authenticator"/>
+                  </form>
                 </td>
               </tr>
             </tal:repeat>

--- a/ftw/publisher/sender/browser/publisherConfig.pt
+++ b/ftw/publisher/sender/browser/publisherConfig.pt
@@ -97,12 +97,17 @@
                   <td tal:content="realm/url" />
                   <td tal:content="realm/username" />
                   <td>
-                    <a href="@@publisher-config-editRealm?id=X"
-                       tal:attributes="href string:@@publisher-config-editRealm?form.widgets.id=${realm/id}"
-                       class="context"
-                       i18n:translate="link_edit_realm"
-                       tal:condition="view/config/is_update_realms_possible"
-                       >Edit</a>
+                    <form method="POST" tal:attributes="action string:@@publisher-config-editRealm">
+                      <input type="hidden" name="form.widgets.id" tal:attributes="value realm/id"/>
+                      <button type="submit"
+                              class="context"
+                              i18n:translate="link_edit_realm"
+                              tal:condition="view/config/is_update_realms_possible" >
+                        Edit
+                      </button>
+                      <span tal:replace="structure context/@@authenticator/authenticator"/>
+                    </form>
+
                     <a href="@@publisher-config-deleteRealm?id=X"
                        tal:attributes="href string:@@publisher-config-deleteRealm?id=${realm/id}"
                        onclick="return confirm('Are you sure to delete this realm?')"

--- a/ftw/publisher/sender/browser/publisherConfig.pt
+++ b/ftw/publisher/sender/browser/publisherConfig.pt
@@ -35,7 +35,6 @@
             <b tal:content="view/getQueueSize" i18n:name="amount">666666</b>
             jobs in the queue.
           </p>
-
           <ul>
             <li>
               <a href="@@publisher-config-listJobs" class="standalone"
@@ -48,17 +47,22 @@
                 List executed jobs
               </a>
             </li><li>
-              <a href="@@publisher-config-cleanJobs" class="standalone"
-                 tal:define="msg view/get_clear_confirm_message"
-                 tal:attributes="onclick string:return confirm('$msg')"
-                 i18n:translate="link_clear_queue">
-                Clear queue
-              </a>
+              <form action="@@publisher-config-cleanJobs" method="POST">
+                <button class="standalone"
+                        tal:define="msg view/get_clear_confirm_message"
+                        tal:attributes="onclick string:return confirm('$msg')"
+                        i18n:translate="link_clear_queue">
+                  Clear queue
+                </button>
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+              </form>
             </li><li>
-              <a href="@@publisher-config-executeJobs" class="standalone"
-                 i18n:translate="link_execute_queue">
-                Execute queue
-              </a>
+              <form action="@@publisher-config-executeJobs" method="POST">
+                <button i18n:translate="link_execute_queue">
+                  Execute queue
+                </button>
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+              </form>
             </li><li>
               <a href="@@publisher-config-blacklist" class="standalone"
                  i18n:translate="link_path_blacklist">

--- a/ftw/publisher/sender/browser/views.py
+++ b/ftw/publisher/sender/browser/views.py
@@ -14,7 +14,7 @@ from ftw.publisher.sender.utils import add_transaction_aware_status_message
 from ftw.publisher.sender.utils import get_site_relative_path
 from ftw.publisher.sender.utils import ReceiverTimeoutError
 from ftw.publisher.sender.utils import sendJsonToRealm
-from Products.CMFCore.utils import getToolByName
+from plone.app.uuid.utils import uuidToObject
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.CMFPlone.utils import base_hasattr
 from Products.Five import BrowserView
@@ -400,7 +400,6 @@ class ExecuteQueue(BrowserView):
         job.executed_with_states(state_entries)
 
         # fire AfterPushEvent
-        reference_catalog = getToolByName(self.context, 'reference_catalog')
-        obj = reference_catalog.lookupObject(job.objectUID)
+        obj = uuidToObject(job.objectUID)
         if state is not None:
             event.notify(AfterPushEvent(obj, state, job))

--- a/ftw/publisher/sender/testing.py
+++ b/ftw/publisher/sender/testing.py
@@ -58,13 +58,18 @@ class PublisherSenderLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         if IS_PLONE_4:
             applyProfile(portal, 'ftw.contentpage:default')
+            applyProfile(portal, 'plone.app.referenceablebehavior:default')
+
         applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.publisher.sender:default')
         applyProfile(portal, 'ftw.publisher.sender:example-workflow')
         applyProfile(portal, 'plone.app.relationfield:default')
-        applyProfile(portal, 'plone.app.referenceablebehavior:default')
         applyProfile(portal, 'ftw.publisher.sender.tests:dexterity')
         applyProfile(portal, 'Products.PloneFormGen:default')
+
+        if IS_PLONE_4:
+            applyProfile(portal, 'ftw.publisher.sender.tests:dexterity-plone4')
+
         if IS_AT_LEAST_PLONE_5_1:
             applyProfile(portal, 'plone.app.contenttypes:default')
 

--- a/ftw/publisher/sender/tests/profiles/dexterity-plone4/types/ExampleDxType.xml
+++ b/ftw/publisher/sender/tests/profiles/dexterity-plone4/types/ExampleDxType.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="ExampleDxType">
+    <property name="behaviors" purge="False">
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
+    </property>
+</object>

--- a/ftw/publisher/sender/tests/profiles/dexterity.zcml
+++ b/ftw/publisher/sender/tests/profiles/dexterity.zcml
@@ -13,4 +13,12 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="dexterity-plone4"
+        title="ftw.publisher.sender.tests:dexterity-plone4"
+        directory="dexterity-plone4"
+        description=""
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/publisher/sender/tests/profiles/dexterity/types/ExampleDxType.xml
+++ b/ftw/publisher/sender/tests/profiles/dexterity/types/ExampleDxType.xml
@@ -20,7 +20,6 @@
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.relationfield.behavior.IRelatedItems"/>
-        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
     </property>
 
     <!-- View information -->

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ tests_require = [
     'path.py',
     'Products.PloneFormGen',
     'plone.app.contenttypes',
-    'plone.app.referenceablebehavior',
     'plone.app.relationfield',
     'plone.app.testing',
     'ftw.testing',
@@ -21,9 +20,9 @@ tests_require = [
 
 tests_plone4_require = [
     'ftw.contentpage',
+    'plone.app.referenceablebehavior',
     'Products.PloneFormGen < 1.8.0a',  # Plone 4 Version
 ]
-
 
 setup(name='ftw.publisher.sender',
       version=version,


### PR DESCRIPTION
Resolves #68 

See #68 for more details.

By implementing the CSRF protection for the edit realm button we also fix an edit realm view itself. Before it did not fill the edit form because the method leading to the form was GET and the form itself was POST ==> https://github.com/plone/Products.CMFPlone/blob/cf96196e06080fb7fafe57d9454bc2c1f3e3ec58/Products/CMFPlone/patches/z3c_form.py#L14-L35