### PR TITLE
Use plone 5 as default when developing

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 [instance]


### PR DESCRIPTION
to keep the setup the same across packages