### PR TITLE
collective.easyform safe data download support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add collective.easyform support: download remote data of safe data adapter. [jone]
 
 
 2.13.0 (2019-11-27)

--- a/ftw/publisher/sender/configure.zcml
+++ b/ftw/publisher/sender/configure.zcml
@@ -25,6 +25,7 @@
     <include file="profiles.zcml" />
     <include package=".upgrades" />
     <include package=".FormGen" zcml:condition="installed Products.PloneFormGen" />
+    <include package=".easyform" zcml:condition="installed collective.easyform" />
 
     <include zcml:condition="installed ftw.lawgiver" file="lawgiver.zcml" />
     <include zcml:condition="have ftw.publisher.sender:taskqueue" package=".taskqueue" />

--- a/ftw/publisher/sender/easyform/actions.py
+++ b/ftw/publisher/sender/easyform/actions.py
@@ -1,0 +1,59 @@
+from collective.easyform.api import get_context
+from ftw.publisher.sender.interfaces import IConfig
+from ftw.publisher.sender.utils import sendRequestToRealm
+from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
+from zope.component import getMultiAdapter
+from zope.component.hooks import getSite
+import os
+
+
+def download(self, response):
+    """This patch combines the data from the sender installation and the receiver
+    installation to one csv / tsv.
+    We assume that the form config is the same on both sides.
+
+    The concept is to first execute the standard implementation, which sets the
+    response headers and streams the local data.
+
+    If the context is considered public, the second step is to get the data from
+    the remote realms and append it to the response body (with response.write).
+
+    This will combine the data of the all sites in a streamed http response.
+
+    This implementation also works in local development with two plone sites,
+    assuming that the receiver side does not have any realms configured.
+    """
+
+    self._old_download(response)
+
+    site = getSite()
+    realms = IConfig(site).getRealms()
+    if not realms:
+        return
+
+    pub_state = getMultiAdapter((get_context(self), response), IPublisherContextState)
+    if not pub_state.is_parent_published():
+        return
+
+    site_path = '/'.join(site.getPhysicalPath())
+    context_path = '/'.join(get_context(self).getPhysicalPath())
+    relative_path = os.path.relpath(context_path, site_path)
+    view_path = '/'.join((relative_path, '@@actions', self.__name__, '@@data'))
+
+    for realm in realms:
+        remote_response = sendRequestToRealm(getSite().REQUEST.form.copy(),
+                                             realm,
+                                             view_path.lstrip('/'),
+                                             return_response=True)
+
+        if remote_response.code != 200:
+            raise ValueError('Bad response from remote realm ({} {}): {!r}..'.format(
+                remote_response.code,
+                remote_response.msg,
+                remote_response.read(100),
+            ))
+
+        try:
+            response.write(remote_response.read())
+        finally:
+            remote_response.close()

--- a/ftw/publisher/sender/easyform/configure.zcml
+++ b/ftw/publisher/sender/easyform/configure.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
+    i18n_domain="ftw.publisher.sender">
+
+    <include package="collective.monkeypatcher" />
+
+    <monkey:patch
+        description="This is a fix to get the data from a public site when on the editorial site."
+        class="collective.easyform.actions.SaveData"
+        original="download"
+        replacement=".actions.download"
+        preserveOriginal="True"
+        />
+
+</configure>

--- a/ftw/publisher/sender/utils.py
+++ b/ftw/publisher/sender/utils.py
@@ -83,7 +83,7 @@ def sendJsonToRealm(json, realm, serverAction):
     return communication.parseResponse(html)
 
 
-def sendRequestToRealm(data, realm, serverAction):
+def sendRequestToRealm(data, realm, serverAction, return_response=False):
     """
     Makes a HTTP-Request to a realm and sends the given data on
     the provided serverAction
@@ -94,6 +94,9 @@ def sendRequestToRealm(data, realm, serverAction):
     @type realm:            Realm
     @param serverAction:    Name of the BrowserView on the target instance
     @type serverAction:     string
+    @param return_response: When True, returns the response object instead of
+                            the body.
+    @type return_response:  bool
     @return:                Response Text
     @rtype:                 string
     """
@@ -114,6 +117,9 @@ def sendRequestToRealm(data, realm, serverAction):
         response = urllib2.urlopen(request, timeout=120)
     except socket.timeout as error:
         raise ReceiverTimeoutError(error)
+
+    if return_response:
+        return response
 
     try:
         return response.read()


### PR DESCRIPTION
The goal is that downloading the safe data adapter data on the editorial site will also include the data of the public facing site because editors usually cannot log into the public facing site.

The patch combines the data from the sender installation and the receiver installation to one csv / tsv. We assume that the form config is the same on both sides

The concept is to first execute the standard implementation, which sets the response headers and streams the local data.

If the context is considered public, the second step is to get the data from the remote realms and append it to the response body (with response.write).

This will combine the data of the all sites in a streamed http response.

This implementation also works in local development with two plone sites, assuming that the receiver side does not have any realms configured.

⚠️ I have not written any tests for this code. The reason is that it quite hard to actually prove that this works in a test. We basically would have to set up two plone sites, which we don't have the testing tools for at the momen. ZSERVER testing could be used for opening a port, but this will change in the future with the new Zope versin.