### PR TITLE
Fix references on new page onto itself are matched as unpublished

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Add collective.easyform support: download remote data of safe data adapter. [jone]
+- Fix references on new page onto itself are matched as unpublished [Nachtalb]
 
 
 2.13.0 (2019-11-27)

--- a/ftw/publisher/sender/workflows/contextstate.py
+++ b/ftw/publisher/sender/workflows/contextstate.py
@@ -2,6 +2,7 @@ from Acquisition import aq_parent, aq_inner
 from Products.Archetypes.interfaces.referenceable import IReferenceable
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from ftw.publisher.core.belongs_to_parent import get_main_obj_belonging_to
 from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
 from ftw.publisher.sender.workflows.interfaces import IWorkflowConfigs
 from operator import attrgetter
@@ -55,12 +56,14 @@ class PublisherContextState(object):
         if IPloneSiteRoot.providedBy(self.context):
             return True
 
+        main_obj = get_main_obj_belonging_to(self.context)
         configs = getUtility(IWorkflowConfigs)
-        return configs.is_published(self.context) or self.is_in_revision()
+        return configs.is_published(main_obj) or self.is_in_revision()
 
     def is_in_revision(self):
+        main_obj = get_main_obj_belonging_to(self.context)
         configs = getUtility(IWorkflowConfigs)
-        return configs.is_in_revision(self.context)
+        return configs.is_in_revision(main_obj)
 
     def get_closest_parent_having_workflow(self):
         """Visits the parents of an object by walking up. If the parent

--- a/ftw/publisher/sender/workflows/example.py
+++ b/ftw/publisher/sender/workflows/example.py
@@ -5,9 +5,7 @@ from ftw.publisher.sender.workflows import interfaces
 from ftw.publisher.sender.workflows.constraints import error_on
 from ftw.publisher.sender.workflows.constraints import message
 from ftw.publisher.sender.workflows.constraints import warning_on
-from ftw.publisher.sender.workflows.interfaces import IPublisherContextState
-from zope.component import getMultiAdapter
-
+from ftw.publisher.core.belongs_to_parent import get_main_obj_belonging_to
 
 class ExampleWorkflowConfiguration(config.LawgiverWorkflowConfiguration):
     workflow_id = 'publisher-example-workflow'
@@ -47,18 +45,12 @@ class ExampleWorkflowConstraintDefinition(constraints.ConstraintDefinition):
     @message(_('The referenced object ${item} is not yet published.'))
     @warning_on(interfaces.PUBLISH, interfaces.SUBMIT)
     def references_should_be_published(self):
-        def does_not_share_workflow_with_current_context(target):
-            target_state = getMultiAdapter((target, self.request), IPublisherContextState)
-            if not target_state.has_workflow() and \
-               target_state.get_closest_parent_having_workflow() == self.context:
-                # The reference target is an object within the current object (self.context)
-                # and the target is a direct or indirect child of the current object without
-                # an own workflow.
-                # This means that the reference will most likely be published along with the
-                # current object. In this situation we do not want to warn.
-                return False
-            return True
-        return list(filter(does_not_share_workflow_with_current_context,
+        main_obj = get_main_obj_belonging_to(self.context)
+
+        def reference_is_not_reference_to_self(target):
+            return get_main_obj_belonging_to(target) != main_obj
+
+        return list(filter(reference_is_not_reference_to_self,
                            self.state().get_unpublished_references()))
 
     @message(_('The referenced object ${item} is still published.'))

--- a/sources.cfg
+++ b/sources.cfg
@@ -4,3 +4,6 @@ extensions = mr.developer
 
 auto-checkout =
   ftw.publisher.core
+
+[branches]
+ftw.publisher.core = ne/get-parent-belonging-to-child


### PR DESCRIPTION
<img width="1030" alt="Screenshot 2020-01-28 at 19 08 42" src="https://user-images.githubusercontent.com/9467802/73292169-d722bd00-4201-11ea-81df-bf18185d5774.png">

A user creates a new page. Within this page, he creates a textblock that references this newly created page. User hits publish: 
Expected:
The site gets published with no warnings
Reality:
The site was published with an error that the site that is being published is not yet published.

The same was the case for items inside other items on that page. So eg. for links to files inside a filelistingblock inside this newly created page.


❗️ Needs https://github.com/4teamwork/ftw.publisher.core/pull/63. ATM this is in the `sources.cfg`. This must be removed and set as min version requirement in the `setup.py` following the merge of https://github.com/4teamwork/ftw.publisher.core/pull/63
