### PR TITLE
Fix reference test and message

### DIFF
--- a/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
+++ b/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
@@ -22,7 +22,6 @@ EXAMPLE_WF_REVISION = 'publisher-example-workflow--STATUS--revision'
 
 class TestExampleWFConstraintDefinition(FunctionalTestCase):
 
-
     def setUp(self):
         super(TestExampleWFConstraintDefinition, self).setUp()
         self.grant('Manager')
@@ -243,14 +242,14 @@ class TestExampleWFConstraintDefinition(FunctionalTestCase):
 
     @browsing
     def test_warning_on_retract_when_references_are_still_published(self, browser):
-        page=create(Builder('page')
+        page = create(Builder('page')
                       .titled(u'The Page'))
-        other_page=create(Builder('page')
+        other_page = create(Builder('page')
                             .titled(u'The Other Page'))
         helpers.set_related_items(page, other_page)
 
-        api.content.transition(obj=page,to_state=EXAMPLE_WF_PUBLISHED)
-        api.content.transition(obj=other_page,to_state=EXAMPLE_WF_PUBLISHED)
+        api.content.transition(obj=page, to_state=EXAMPLE_WF_PUBLISHED)
+        api.content.transition(obj=other_page, to_state=EXAMPLE_WF_PUBLISHED)
         transaction.commit()
 
         browser.login().visit(page)

--- a/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
+++ b/ftw/publisher/sender/tests/test_example_workflow_constraint_definition.py
@@ -239,8 +239,8 @@ class TestExampleWFConstraintDefinition(FunctionalTestCase):
         browser.login().visit(source_page)
         Workflow().do_transition('publish')
 
-        statusmessages.assert_message('The referenced object <a href="{}">Target Block</a> is not yet published.'.format(
-            target_textblock.absolute_url()))
+        statusmessages.assert_message('The referenced object <a href="{}">Target</a> is not yet published.'.format(
+            target_page.absolute_url()))
 
     @browsing
     def test_warning_on_retract_when_references_are_still_published(self, browser):

--- a/ftw/publisher/sender/workflows/example.py
+++ b/ftw/publisher/sender/workflows/example.py
@@ -48,13 +48,14 @@ class ExampleWorkflowConstraintDefinition(constraints.ConstraintDefinition):
     def references_should_be_published(self):
         main_obj = get_main_obj_belonging_to(self.context)
 
-        def reference_is_not_reference_to_self(target):
-            return get_main_obj_belonging_to(target) != main_obj
+        def reference_is_not_reference_to_self(target_main_obj):
+            return target_main_obj != main_obj
 
         return list(filter(reference_is_not_reference_to_self,
-                           self.state().get_unpublished_references()))
+                           map(get_main_obj_belonging_to,
+                               self.state().get_unpublished_references())))
 
     @message(_('The referenced object ${item} is still published.'))
     @warning_on(interfaces.DELETE, interfaces.RETRACT)
     def references_may_be_retracted_too(self):
-        return list(self.state().get_published_references())
+        return list(map(get_main_obj_belonging_to, self.state().get_published_references()))

--- a/ftw/publisher/sender/workflows/example.py
+++ b/ftw/publisher/sender/workflows/example.py
@@ -7,6 +7,7 @@ from ftw.publisher.sender.workflows.constraints import message
 from ftw.publisher.sender.workflows.constraints import warning_on
 from ftw.publisher.core.belongs_to_parent import get_main_obj_belonging_to
 
+
 class ExampleWorkflowConfiguration(config.LawgiverWorkflowConfiguration):
     workflow_id = 'publisher-example-workflow'
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -4,6 +4,3 @@ extensions = mr.developer
 
 auto-checkout =
   ftw.publisher.core
-
-[branches]
-ftw.publisher.core = ne/get-parent-belonging-to-child


### PR DESCRIPTION
Merge target: #73 

Contains:
- Fix for the broken test in #73 
- Change: we are now linking the main object in the message (the content page instead of the textblock); makes more sense for the user
- Pep8 clenaup
- Use `master` of `ftw.publisher.core`