### PR TITLE
Support save data adapter which returns excel format.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -317,9 +317,13 @@ Disable creating publisher jobs
         pass  # no publisher jobs created here.
 
 
-FormGen integration
+FormGen / EasyForm integration
 ===================
 The FormGen integration allows it to download the data entered on a published site. If the content is published it will get the data from from the public site. If it isn't published it will use the local data. The reason for this distinction is that we support internal forms, which are never published at all. In this case the internally collected data should be downloaded.
+
+Further hint for EasyForm: Easyform supports Excel as export format from saved data. In order to support this ``openpyxl`` is required.
+openpyxl will compine the two excel files (local and remote) and return it
+
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support save data adapter which returns excel format. [mathias.leimgruber]
 
 
 2.14.1 (2020-07-30)

--- a/ftw/publisher/sender/tests/assets/folder_dx.json
+++ b/ftw/publisher/sender/tests/assets/folder_dx.json
@@ -31,7 +31,7 @@
             "utf8:exclude_from_nav": null
         },
         "utf8:INextPreviousToggle": {
-            "utf8:nextPreviousEnabled": false
+            "utf8:nextPreviousEnabled": null
         },
         "utf8:IRelatedItems": {
             "utf8:relatedItems": [


### PR DESCRIPTION
This PR includes the logic to combine the local and a remote excel file from EasyForm saved data.
- collective.easyform supports XLSX export since version 2.3.x. (https://github.com/collective/collective.easyform/pull/283)

It also fixes a endless loop, when both plone sites (edit and www) are running within the same dev. instance.
