### PR TITLE
Create a move job upon object_rename view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Create a move job upon object_rename view (Plone 5 only). [mathias.leimgruber]
 
 
 2.14.2 (2021-07-16)

--- a/ftw/publisher/sender/eventhandlers.py
+++ b/ftw/publisher/sender/eventhandlers.py
@@ -27,6 +27,7 @@ def add_move_job(obj, event):
         if url_endswith not in ['folder_rename_form',
                                 'folder_paste',
                                 'manage_pasteObjects',
+                                'object_rename',
                                 'object_paste']:
             return
         # set event info on


### PR DESCRIPTION
This fixes inconsistencies if objects are getting renamed via "Action -> Rename". 

